### PR TITLE
Removed static limit on render and preview api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,6 +4724,7 @@ dependencies = [
  "getrandom 0.3.4",
  "indicatif",
  "itertools 0.14.0",
+ "paste",
  "pollster",
  "pretty_env_logger",
  "profiling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ profiling = { version = "1.0.17", optional = true, features = [
   "profile-with-puffin",
 ] }
 async-channel = "2.5.0"
+paste = "1.0"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 pretty_env_logger = "0.5.0"

--- a/benches/benches/render.rs
+++ b/benches/benches/render.rs
@@ -17,7 +17,7 @@ fn render_benchmark(c: &mut Criterion) {
                     format!("static_squares_{n}"),
                     &SceneConfig::default(),
                     &Output {
-                        dir: "bench",
+                        dir: "bench".to_string(),
                         ..Default::default()
                     },
                 );
@@ -31,7 +31,7 @@ fn render_benchmark(c: &mut Criterion) {
                     format!("transform_squares_{n}"),
                     &SceneConfig::default(),
                     &Output {
-                        dir: "bench",
+                        dir: "bench".to_string(),
                         ..Default::default()
                     },
                 );

--- a/example-packages/app/src/main.rs
+++ b/example-packages/app/src/main.rs
@@ -1,5 +1,4 @@
 use app::hello_ranim_scene;
-use ranim::cmd::preview::preview_scene;
 
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
@@ -7,5 +6,5 @@ fn main() {
         .filter(Some("ranim"), log::LevelFilter::Info)
         .init();
 
-    preview_scene(hello_ranim_scene);
+    ranim::preview_scene!(hello_ranim);
 }

--- a/examples/thesis/main.rs
+++ b/examples/thesis/main.rs
@@ -107,18 +107,16 @@ fn transform(r: &mut RanimScene) {
 fn main() {
     #[cfg(feature = "preview")]
     {
-        use ranim::cmd::preview_scene;
-        preview_scene(fading_scene);
-        preview_scene(creation_scene);
-        preview_scene(writing_scene);
-        preview_scene(transform_scene);
+        ranim::preview_scene!(fading);
+        ranim::preview_scene!(creation);
+        ranim::preview_scene!(writing);
+        ranim::preview_scene!(transform);
     }
     #[cfg(feature = "render")]
     {
-        use ranim::cmd::render_scene;
-        render_scene(fading_scene);
-        render_scene(creation_scene);
-        render_scene(writing_scene);
-        render_scene(transform_scene);
+        ranim::render_scene!(fading);
+        ranim::render_scene!(creation);
+        ranim::render_scene!(writing);
+        ranim::render_scene!(transform);
     }
 }

--- a/packages/ranim-app/src/lib.rs
+++ b/packages/ranim-app/src/lib.rs
@@ -147,7 +147,7 @@ impl RanimApp {
                     self.pool.clean();
                     self.need_eval = true;
 
-                    self.set_clear_color_str(scene.config.clear_color);
+                    self.set_clear_color_str(&scene.config.clear_color);
 
                     if let Err(err) = tx.try_send(()) {
                         error!("Failed to send reloaded signal: {err:?}");
@@ -479,15 +479,15 @@ pub fn preview_constructor_with_name(scene: impl SceneConstructor, name: &str) {
     );
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+/// Preview a scene
 pub fn preview_scene(scene: &Scene) {
-    preview_scene_with_name(scene, scene.name);
+    preview_scene_with_name(scene, &scene.name.clone());
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+/// Preview a scene with a custom name
 pub fn preview_scene_with_name(scene: &Scene, name: &str) {
     let mut app = RanimApp::new(scene.constructor, name.to_string());
-    app.set_clear_color_str(scene.config.clear_color);
+    app.set_clear_color_str(&scene.config.clear_color);
     run_app(
         app,
         #[cfg(target_arch = "wasm32")]
@@ -498,11 +498,17 @@ pub fn preview_scene_with_name(scene: &Scene, name: &str) {
 // WASM support needs refactoring, mostly keeping it commented or adapting basic entry point.
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use wasm_bindgen::prelude::*;
+    use super::*;
 
     #[wasm_bindgen(start)]
     pub async fn wasm_start() {
         console_error_panic_hook::set_once();
         wasm_tracing::set_as_global_default();
+    }
+
+    /// WASM wrapper: preview a scene (accepts owned [`Scene`] from `find_scene`)
+    #[wasm_bindgen]
+    pub fn preview_scene(scene: &Scene) {
+        super::preview_scene(scene);
     }
 }

--- a/packages/ranim-cli/src/cli/preview.rs
+++ b/packages/ranim-cli/src/cli/preview.rs
@@ -151,7 +151,7 @@ pub fn preview_command(args: &CliArgs, scene_name: &Option<String>) -> Result<()
         .expect("Failed on initial build");
 
     let scene = match scene_name {
-        Some(scene) => lib.scenes().find(|s| s.name == scene),
+        Some(scene) => lib.scenes().find(|s| s.name == *scene),
         None => lib.scenes().next(),
     }
     .ok_or(anyhow::anyhow!("Failed to find preview scene"))?;
@@ -160,8 +160,8 @@ pub fn preview_command(args: &CliArgs, scene_name: &Option<String>) -> Result<()
     //     info!("- {:?}", scene.name);
     // }
     // panic!("Failed to get preview scene");
-    let mut app = RanimApp::new(scene.constructor, scene.name.to_string());
-    app.set_clear_color_str(scene.config.clear_color);
+    let mut app = RanimApp::new(scene.constructor, scene.name.clone());
+    app.set_clear_color_str(&scene.config.clear_color);
     let cmd_tx = app.cmd_tx.clone();
 
     let scene_name = scene_name.clone();
@@ -180,7 +180,7 @@ pub fn preview_command(args: &CliArgs, scene_name: &Option<String>) -> Result<()
                 && let Ok(new_lib) = new_lib
             {
                 let scene = match &scene_name {
-                    Some(scene) => new_lib.scenes().find(|s| s.name == scene),
+                    Some(name) => new_lib.scenes().find(|s| s.name == *name),
                     None => new_lib.scenes().next(),
                 }
                 .ok_or(anyhow::anyhow!("Failed to find preview scene"));

--- a/packages/ranim-cli/src/cli/render.rs
+++ b/packages/ranim-cli/src/cli/render.rs
@@ -37,14 +37,13 @@ pub fn render_command(args: &CliArgs, scenes: &[String]) -> Result<()> {
         .unwrap()
         .context("Failed on initial build")?;
 
-    let all_scenes: Vec<&Scene> = lib.scenes().collect::<Vec<_>>();
+    let all_scenes: Vec<Scene> = lib.scenes().collect::<Vec<_>>();
     let scenes_to_render: Vec<&Scene> = if scenes.is_empty() {
-        all_scenes.clone()
+        all_scenes.iter().collect()
     } else {
         all_scenes
             .iter()
-            .filter(|scene| scenes.iter().any(|s| s == scene.name))
-            .cloned()
+            .filter(|scene| scenes.iter().any(|s| s == &scene.name))
             .collect()
     };
 

--- a/packages/ranim-core/src/link_magic.rs
+++ b/packages/ranim-core/src/link_magic.rs
@@ -1,0 +1,117 @@
+//! Scene types for dylib / inventory registration and runtime use.
+
+use crate::{Output, RanimScene, Scene, SceneConfig};
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+// MARK: Static types (for inventory registration)
+
+/// Static scene type for inventory registration
+#[doc(hidden)]
+pub struct StaticScene {
+    /// Scene name
+    pub name: &'static str,
+    /// Scene constructor
+    pub constructor: fn(&mut RanimScene),
+    /// Scene config
+    pub config: StaticSceneConfig,
+    /// Scene outputs
+    pub outputs: &'static [StaticOutput],
+}
+
+/// Static scene config for inventory registration
+#[doc(hidden)]
+pub struct StaticSceneConfig {
+    /// The clear color
+    pub clear_color: &'static str,
+}
+
+/// Static output for inventory registration
+#[doc(hidden)]
+pub struct StaticOutput {
+    /// The width of the output texture in pixels.
+    pub width: u32,
+    /// The height of the output texture in pixels.
+    pub height: u32,
+    /// The frame rate of the output video.
+    pub fps: u32,
+    /// Whether to save the frames.
+    pub save_frames: bool,
+    /// The directory to save the output
+    pub dir: &'static str,
+}
+
+impl StaticOutput {
+    /// 1920x1080 60fps save_frames=false dir="./"
+    pub const DEFAULT: Self = Self {
+        width: 1920,
+        height: 1080,
+        fps: 60,
+        save_frames: false,
+        dir: "./",
+    };
+}
+
+// MARK: inventory + FFI
+
+pub use inventory;
+
+inventory::collect!(StaticScene);
+
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub extern "C" fn get_scene(idx: usize) -> *const StaticScene {
+    inventory::iter::<StaticScene>()
+        .skip(idx)
+        .take(1)
+        .next()
+        .unwrap()
+}
+
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub extern "C" fn scene_cnt() -> usize {
+    inventory::iter::<StaticScene>().count()
+}
+
+/// Return a scene with matched name
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+pub fn find_scene(name: &str) -> Option<Scene> {
+    inventory::iter::<StaticScene>()
+        .find(|s| s.name == name)
+        .map(Scene::from)
+}
+
+// MARK: From impls (Static -> Owned)
+
+impl From<&StaticScene> for Scene {
+    fn from(s: &StaticScene) -> Self {
+        Self {
+            name: s.name.to_string(),
+            constructor: s.constructor,
+            config: SceneConfig::from(&s.config),
+            outputs: s.outputs.iter().map(Output::from).collect(),
+        }
+    }
+}
+
+impl From<&StaticSceneConfig> for SceneConfig {
+    fn from(c: &StaticSceneConfig) -> Self {
+        Self {
+            clear_color: c.clear_color.to_string(),
+        }
+    }
+}
+
+impl From<&StaticOutput> for Output {
+    fn from(o: &StaticOutput) -> Self {
+        Self {
+            width: o.width,
+            height: o.height,
+            fps: o.fps,
+            save_frames: o.save_frames,
+            dir: o.dir.to_string(),
+        }
+    }
+}

--- a/packages/ranim-macros/src/lib.rs
+++ b/packages/ranim-macros/src/lib.rs
@@ -86,15 +86,15 @@ pub fn scene(args: TokenStream, input: TokenStream) -> TokenStream {
     // 场景名称
     let scene_name = attrs.name.unwrap_or_else(|| fn_name.to_string());
 
-    // SceneConfig
+    // StaticSceneConfig
     let clear_color = attrs.clear_color.unwrap_or("#333333ff".to_string());
     let scene_config = quote! {
-        #ranim::SceneConfig {
+        #ranim::StaticSceneConfig {
             clear_color: #clear_color,
         }
     };
 
-    // Output 列表
+    // StaticOutput 列表
     let mut outputs = Vec::new();
     for OutputDef {
         width,
@@ -105,7 +105,7 @@ pub fn scene(args: TokenStream, input: TokenStream) -> TokenStream {
     } in attrs.outputs
     {
         outputs.push(quote! {
-            #ranim::Output {
+            #ranim::StaticOutput {
                 width: #width,
                 height: #height,
                 fps: #fps,
@@ -116,7 +116,7 @@ pub fn scene(args: TokenStream, input: TokenStream) -> TokenStream {
     }
     if outputs.is_empty() {
         outputs.push(quote! {
-            #ranim::Output::DEFAULT
+            #ranim::StaticOutput::DEFAULT
         });
     }
 
@@ -145,7 +145,7 @@ pub fn scene(args: TokenStream, input: TokenStream) -> TokenStream {
     let output_cnt = outputs.len();
 
     let scene = quote! {
-        #ranim::Scene {
+        #ranim::StaticScene {
             name: #scene_name,
             constructor: #fn_name,
             config: #scene_config,
@@ -153,21 +153,21 @@ pub fn scene(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     };
 
-    // 构造 Scene 并塞进分布式切片
+    // 构造 StaticScene 并塞进分布式切片
     let expanded = quote! {
         #doc
         #(#doc_attrs)*
         #vis fn #fn_name(r: &mut #ranim::RanimScene) #fn_body
 
-        static #static_output_name: [#ranim::Output; #output_cnt] = [#(#outputs),*];
+        static #static_output_name: [#ranim::StaticOutput; #output_cnt] = [#(#outputs),*];
         #[doc(hidden)]
-        static #static_name: #ranim::Scene = #scene;
+        static #static_name: #ranim::StaticScene = #scene;
         #ranim::inventory::submit!{
             #scene
         }
 
         #[allow(non_upper_case_globals)]
-        #vis static #static_scene_name: &'static #ranim::Scene = &#static_name;
+        #vis static #static_scene_name: &'static #ranim::StaticScene = &#static_name;
     };
 
     TokenStream::from(expanded)

--- a/src/cmd/render.rs
+++ b/src/cmd/render.rs
@@ -19,15 +19,10 @@ mod file_writer;
 #[cfg(feature = "profiling")]
 use ranim_render::PUFFIN_GPU_PROFILER;
 
-/// Render a scene
+/// Render a scene with all its outputs
 pub fn render_scene(scene: &Scene) {
-    for output in scene.outputs {
-        render_scene_output(
-            scene.constructor,
-            scene.name.to_string(),
-            &scene.config,
-            output,
-        );
+    for output in &scene.outputs {
+        render_scene_output(scene.constructor, scene.name.clone(), &scene.config, output);
     }
 }
 
@@ -117,7 +112,7 @@ impl RenderWorker {
         let ctx = pollster::block_on(WgpuContext::new());
         trace!("Create wgpu context cost: {:?}", t.elapsed());
 
-        let mut output_dir = PathBuf::from(output.dir);
+        let mut output_dir = PathBuf::from(&output.dir);
         if !output_dir.is_absolute() {
             output_dir = std::env::current_dir()
                 .unwrap()
@@ -125,7 +120,7 @@ impl RenderWorker {
                 .join(output_dir);
         }
         let renderer = Renderer::new(&ctx, output.width, output.height, 8);
-        let clear_color = color::try_color(scene_config.clear_color)
+        let clear_color = color::try_color(&scene_config.clear_color)
             .unwrap_or(color::color("#333333ff"))
             .convert::<LinearSrgb>();
         let [r, g, b, a] = clear_color.components.map(|x| x as f64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,43 @@ pub mod utils {
 }
 
 pub use core::{glam, inventory};
-pub use ranim_core::{Output, RanimScene, Scene, SceneConfig, SceneConstructor};
+pub use paste;
+pub use ranim_core::{
+    Output, RanimScene, Scene, SceneConfig, SceneConstructor, StaticOutput, StaticScene,
+    StaticSceneConfig,
+};
+
+/// Render a scene by name. Expands `render_scene!(foo)` to call
+/// `cmd::render_scene(&Scene::from(foo_scene))`.
+///
+/// ```rust,ignore
+/// render_scene!(fading);
+/// ```
+#[cfg(all(not(target_family = "wasm"), feature = "render"))]
+#[macro_export]
+macro_rules! render_scene {
+    ($scene:ident) => {
+        $crate::paste::paste! {
+            $crate::cmd::render_scene(&$crate::Scene::from([< $scene _scene >]))
+        }
+    };
+}
+
+/// Preview a scene by name. Expands `preview_scene!(foo)` to call
+/// `cmd::preview_scene(&Scene::from(foo_scene))`.
+///
+/// ```rust,ignore
+/// preview_scene!(fading);
+/// ```
+#[cfg(feature = "preview")]
+#[macro_export]
+macro_rules! preview_scene {
+    ($scene:ident) => {
+        $crate::paste::paste! {
+            $crate::cmd::preview_scene(&$crate::Scene::from([< $scene _scene >]))
+        }
+    };
+}
 
 /// The preludes
 pub mod prelude {


### PR DESCRIPTION
Proc macro now generates `StaticScene` with `StaticOutput` and `StaticSceneConfig`, they can be converted into the owned version `Scene`, `Output` and `SceneConfig`.

Ffi method `get_scene` still returns pointer to `StaticScene`, since it has to be compatible with c abi.

`find_scene` now returns the owned `Scene`, and all api now accepts the owned `Scene`'s reference.

Added two macro `render_scene!` and `preview_scene!` which can directly pass in the func name of the scene. Inner uses somthing like this:

```rust
&$crate::Scene::from([< $scene _scene >])
```