### PR TITLE
feat(preview): support dynamic resolution with aspect ratio presets

### DIFF
--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -93,7 +93,7 @@ impl Resolution {
     pub const HD: Self = Self::new(1280, 720);
     pub const FHD: Self = Self::new(1920, 1080);
     pub const QHD: Self = Self::new(2560, 1440);
-    pub const _4K: Self = Self::new(3840, 2160);
+    pub const UHD: Self = Self::new(3840, 2160);
     // 16:10
     pub const WXGA: Self = Self::new(1280, 800);
     pub const WUXGA: Self = Self::new(1920, 1200);
@@ -467,8 +467,8 @@ impl eframe::App for RanimPreviewApp {
                             );
                             ui.selectable_value(
                                 &mut self.resolution,
-                                Resolution::_4K,
-                                "3840x2160 (4K)",
+                                Resolution::UHD,
+                                "3840x2160 (UHD)",
                             );
                             ui.separator();
                             // 16:10


### PR DESCRIPTION
Closes: #155

- **feat**: Add dynamic resolution selection for RanimPreviewApp
- **feat**: Auto-adjust OIT layers based on GPU buffer size limits to prevent UHD crashes

---

## Dynamic Resolution Selection

Preview app now supports runtime resolution switching via a dropdown menu:

- **16:9**
  - 1280x720 (HD)
  - 1920x1080 (FHD)
  - 2560x1440 (QHD)
  - 3840x2160 (UHD)
- **16:10**
  - 1280x800 (WXGA)
  - 1920x1200 (WUXGA)
- **4:3**
  - 800x600 (SVGA)
  - 1024x768 (XGA)
  - 1280x960 (SXGA)
- **1:1**
  - 1080x1080
  - 2160x2160
- **21:9**
  - 3440x1440 (UW-QHD)

## OIT Layer Auto-Adjustment

High resolutions (e.g., UHD) can exceed GPU `max_storage_buffer_binding_size` limits, causing panics. The app now:

1. Queries GPU limits at runtime
2. Calculates max OIT layers that fit within buffer size
3. Logs a warning when layers are reduced:

```
WARN OIT layers reduced from 8 to 2 due to GPU buffer size limit (128MB @ 3840x2160)
```

## API

```rust
pub struct Resolution {
    pub width: u32,
    pub height: u32,
}

impl Resolution {
    // Aspect ratio is computed via GCD
    pub fn aspect_ratio(&self) -> (u32, u32);  // e.g., (16, 9)
    pub fn aspect_ratio_str(&self) -> String;  // e.g., "16:9"
    
    // Presets
    pub const HD: Self;      // 1280x720
    pub const FHD: Self;     // 1920x1080
    pub const QHD: Self;     // 2560x1440
    pub const UHD: Self;     // 3840x2160
    // ...
}

// Usage
app.set_resolution(Resolution::UHD);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)