### PR TITLE
feat(preview): improve export UX and simplify Output.dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui-phosphor"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b2838620355debaeb7fa3cc331a1d8ab77e6387d40e65686fa468c229dbf63"
+dependencies = [
+ "egui",
+]
+
+[[package]]
 name = "egui-wgpu"
 version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4765,6 +4774,7 @@ dependencies = [
  "derive_more",
  "eframe",
  "egui",
+ "egui-phosphor",
  "flate2",
  "getrandom 0.3.4",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ preview = [
   "render",
   "dep:egui",
   "dep:eframe",
+  "dep:egui-phosphor",
   "dep:web-time",
   "dep:bytemuck",
   "dep:wasm-bindgen-futures",
@@ -103,6 +104,7 @@ ranim-render = { workspace = true, optional = true }
 wgpu = { workspace = true, optional = true }
 # app feature
 egui = { version = "0.33.0", optional = true }
+egui-phosphor = { version = "0.11.0", optional = true }
 web-time = { version = "1.1.0", optional = true }
 bytemuck = { workspace = true, features = ["derive"], optional = true }
 # profiling

--- a/benches/benches/render.rs
+++ b/benches/benches/render.rs
@@ -17,7 +17,7 @@ fn render_benchmark(c: &mut Criterion) {
                     format!("static_squares_{n}"),
                     &SceneConfig::default(),
                     &Output {
-                        dir: "bench".to_string(),
+                        dir: "./output/bench".to_string(),
                         ..Default::default()
                     },
                     2,
@@ -32,7 +32,7 @@ fn render_benchmark(c: &mut Criterion) {
                     format!("transform_squares_{n}"),
                     &SceneConfig::default(),
                     &Output {
-                        dir: "bench".to_string(),
+                        dir: "./output/bench".to_string(),
                         ..Default::default()
                     },
                     2,

--- a/examples/aabb/lib.rs
+++ b/examples/aabb/lib.rs
@@ -19,7 +19,7 @@ use ranim::{
 };
 
 #[scene]
-#[output(dir = "aabb")]
+#[output(dir = "./output/aabb")]
 fn aabb(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
 

--- a/examples/animating_pi/lib.rs
+++ b/examples/animating_pi/lib.rs
@@ -11,7 +11,7 @@ use ranim_core::animation::StaticAnim;
 use ranim_items::vitem::{VItem, svg::SvgItem, typst::typst_svg};
 
 #[scene(clear_color = "#000000")]
-#[output(dir = "animating_pi")]
+#[output(dir = "./output/animating_pi")]
 fn animating_pi(r: &mut RanimScene) {
     let cam = CameraFrame::default();
     let _r_cam = r.insert(cam.clone());

--- a/examples/arc/lib.rs
+++ b/examples/arc/lib.rs
@@ -10,7 +10,7 @@ use ranim::{
 use ranim_items::vitem::geometry::anchor::Origin;
 
 #[scene]
-#[output(dir = "arc")]
+#[output(dir = "./output/arc")]
 pub fn arc(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
 

--- a/examples/arc_between_points/lib.rs
+++ b/examples/arc_between_points/lib.rs
@@ -9,7 +9,7 @@ use ranim::{
 };
 
 #[scene]
-#[output(dir = "arc_between_points")]
+#[output(dir = "./output/arc_between_points")]
 fn arc_between_points(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
     let center = dvec2(0.0, 0.0);

--- a/examples/basic/lib.rs
+++ b/examples/basic/lib.rs
@@ -11,7 +11,7 @@ use ranim::{
 const SVG: &str = include_str!("../../assets/Ghostscript_Tiger.svg");
 
 #[scene]
-#[output(dir = "basic")]
+#[output(dir = "./output/basic")]
 fn basic(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
     r.timelines_mut().forward(0.2);

--- a/examples/bubble_sort/lib.rs
+++ b/examples/bubble_sort/lib.rs
@@ -105,13 +105,13 @@ fn bubble_sort(r: &mut RanimScene, num: usize) {
 }
 
 #[scene]
-#[output(dir = "bubble_sort")]
+#[output(dir = "./output/bubble_sort")]
 fn bubble_sort_10(r: &mut RanimScene) {
     bubble_sort(r, 10);
 }
 
 #[scene(name = "bubble_sort")]
-#[output(dir = "bubble_sort")]
+#[output(dir = "./output/bubble_sort")]
 fn bubble_sort_100(r: &mut RanimScene) {
     bubble_sort(r, 100);
 }

--- a/examples/ellipse/lib.rs
+++ b/examples/ellipse/lib.rs
@@ -10,7 +10,7 @@ use ranim::{
 };
 
 #[scene]
-#[output(dir = "ellipse")]
+#[output(dir = "./output/ellipse")]
 fn ellipse(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
 

--- a/examples/extract_vitem_visualize/lib.rs
+++ b/examples/extract_vitem_visualize/lib.rs
@@ -21,7 +21,7 @@ use glam::DVec3;
 
 // MARK: ranim_text
 #[scene]
-#[output(dir = "extract_vitem_visualize")]
+#[output(dir = "./output/extract_vitem_visualize")]
 fn ranim_text(r: &mut RanimScene) {
     let mut cam = CameraFrame::default();
     let r_cam = r.insert(cam.clone());
@@ -60,7 +60,7 @@ fn ranim_text(r: &mut RanimScene) {
 }
 
 #[scene(name = "extract_vitem_visualize")]
-#[output(dir = "extract_vitem_visualize")]
+#[output(dir = "./output/extract_vitem_visualize")]
 pub fn hello_ranim(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
 

--- a/examples/getting_started0/lib.rs
+++ b/examples/getting_started0/lib.rs
@@ -4,7 +4,7 @@ use ranim::{
 
 // ANCHOR: construct
 #[scene]
-#[output(dir = "getting_started0")]
+#[output(dir = "./output/getting_started0")]
 fn getting_started0(r: &mut RanimScene) {
     // Equivalent to creating a new timeline then playing `CameraFrame::default().show()` on it
     let _r_cam = r.insert(CameraFrame::default());

--- a/examples/getting_started1/lib.rs
+++ b/examples/getting_started1/lib.rs
@@ -10,7 +10,7 @@ use ranim::{
 
 // ANCHOR: construct
 #[scene]
-#[output(dir = "getting_started1")]
+#[output(dir = "./output/getting_started1")]
 fn getting_started1(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
     // A Square with size 2.0 and color blue

--- a/examples/getting_started2/lib.rs
+++ b/examples/getting_started2/lib.rs
@@ -13,7 +13,7 @@ use ranim::{
 };
 
 #[scene]
-#[output(dir = "getting_started2")]
+#[output(dir = "./output/getting_started2")]
 fn getting_started2(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
     let rect = Rectangle::new(4.0, 9.0 / 4.0).with(|rect| {

--- a/examples/hanoi/lib.rs
+++ b/examples/hanoi/lib.rs
@@ -109,13 +109,13 @@ fn hanoi(r: &mut RanimScene, n: usize) {
 }
 
 #[scene]
-#[output(dir = "hanoi")]
+#[output(dir = "./output/hanoi")]
 fn hanoi_5(r: &mut RanimScene) {
     hanoi(r, 5);
 }
 
 #[scene(name = "hanoi")]
-#[output(dir = "hanoi")]
+#[output(dir = "./output/hanoi")]
 fn hanoi_10(r: &mut RanimScene) {
     hanoi(r, 10);
 }

--- a/examples/hello_ranim/lib.rs
+++ b/examples/hello_ranim/lib.rs
@@ -11,7 +11,7 @@ use ranim::{
 };
 
 #[scene]
-#[output(dir = "hello_ranim")]
+#[output(dir = "./output/hello_ranim")]
 fn hello_ranim(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
 

--- a/examples/mesh_morph/lib.rs
+++ b/examples/mesh_morph/lib.rs
@@ -11,7 +11,7 @@ use ranim::{
 
 /// Comprehensive mesh morphing demo: sphere -> torus -> disc -> sphere
 #[scene]
-#[output(dir = "mesh_morph")]
+#[output(dir = "./output/mesh_morph")]
 fn mesh_morph(r: &mut RanimScene) {
     // Setup camera
     let phi = 70.0 * PI / 180.0;

--- a/examples/output_formats/lib.rs
+++ b/examples/output_formats/lib.rs
@@ -9,10 +9,10 @@ use ranim::{
 };
 
 #[scene(clear_color = "#00000000")]
-#[output(dir = "output_formats", format = "mp4")]
-#[output(dir = "output_formats", format = "webm")]
-#[output(dir = "output_formats", format = "mov")]
-#[output(dir = "output_formats", format = "gif")]
+#[output(dir = "./output/output_formats", format = "mp4")]
+#[output(dir = "./output/output_formats", format = "webm")]
+#[output(dir = "./output/output_formats", format = "mov")]
+#[output(dir = "./output/output_formats", format = "gif")]
 fn output_formats(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
 

--- a/examples/palettes/lib.rs
+++ b/examples/palettes/lib.rs
@@ -6,7 +6,7 @@ use ranim::{
 };
 
 #[scene]
-#[output(dir = "palettes")]
+#[output(dir = "./output/palettes")]
 fn palettes(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
     let frame_size = dvec2(8.0 * 16.0 / 9.0, 8.0);

--- a/examples/perlin_terrain/lib.rs
+++ b/examples/perlin_terrain/lib.rs
@@ -215,7 +215,7 @@ fn build_terrain_scene(r: &mut RanimScene, height_func: impl Fn(f64, f64) -> f64
 
 /// Basic Perlin noise terrain.
 #[scene]
-#[output(dir = "perlin_terrain/perlin")]
+#[output(dir = "./output/perlin_terrain/perlin")]
 fn perlin(r: &mut RanimScene) {
     // Python: get_noise(x, y, size) → noise(v, u) (note v, u swap)
     // height = noise_func(v, u, size) * depth = noise * depth
@@ -229,7 +229,7 @@ fn perlin(r: &mut RanimScene) {
 
 /// Fractal Perlin noise terrain (octave stacking).
 #[scene]
-#[output(dir = "perlin_terrain/fractal")]
+#[output(dir = "./output/perlin_terrain/fractal")]
 fn fractal_perlin(r: &mut RanimScene) {
     // Python: get_fractal_noise(x, y, size) * depth → fractal_noise(v, u) * depth
     // height = noise_func(v, u, size) * depth = fractal_noise * depth * depth
@@ -246,7 +246,7 @@ fn fractal_perlin(r: &mut RanimScene) {
 
 /// Fractal Perlin noise with derivative-based erosion.
 #[scene(name = "perlin_terrain")]
-#[output(dir = "perlin_terrain/erosion")]
+#[output(dir = "./output/perlin_terrain/erosion")]
 fn fractal_erosion(r: &mut RanimScene) {
     // Same pattern as fractal_perlin but with derivative-based erosion
     build_terrain_scene(r, |u, v| {

--- a/examples/perspective_blend/lib.rs
+++ b/examples/perspective_blend/lib.rs
@@ -10,7 +10,7 @@ use ranim::{
 use ranim_core::animation::StaticAnim;
 
 #[scene]
-#[output(dir = "perspective_blend")]
+#[output(dir = "./output/perspective_blend")]
 fn perspective_blend(r: &mut RanimScene) {
     let mut cam = CameraFrame::default();
     let r_cam = r.insert(cam.clone());

--- a/examples/ranim_logo/lib.rs
+++ b/examples/ranim_logo/lib.rs
@@ -69,7 +69,7 @@ fn build_logo(logo_width: f64) -> [VItem; 6] {
     ]
 }
 #[scene]
-#[output(dir = "ranim_logo")]
+#[output(dir = "./output/ranim_logo")]
 fn ranim_logo(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
     let frame_size = dvec2(8.0 * 16.0 / 9.0, 8.0);

--- a/examples/regular_polygon/lib.rs
+++ b/examples/regular_polygon/lib.rs
@@ -12,7 +12,7 @@ use ranim_core::animation::Eval;
 use ranim_items::vitem::geometry::anchor::Origin;
 
 #[scene]
-#[output(dir = "regular_polygon")]
+#[output(dir = "./output/regular_polygon")]
 pub fn regular_polygon(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
 

--- a/examples/selective_sort/lib.rs
+++ b/examples/selective_sort/lib.rs
@@ -100,13 +100,13 @@ fn selective_sort(r: &mut RanimScene, num: usize) {
 }
 
 #[scene]
-#[output(dir = "selective_sort")]
+#[output(dir = "./output/selective_sort")]
 fn selective_sort_10(r: &mut RanimScene) {
     selective_sort(r, 10);
 }
 
 #[scene(name = "selective_sort")]
-#[output(dir = "selective_sort")]
+#[output(dir = "./output/selective_sort")]
 fn selective_sort_100(r: &mut RanimScene) {
     selective_sort(r, 100);
 }

--- a/examples/solar_system/lib.rs
+++ b/examples/solar_system/lib.rs
@@ -119,7 +119,7 @@ const PLANETS: &[PlanetData] = &[
 ];
 
 #[scene]
-#[output(dir = "solar_system")]
+#[output(dir = "./output/solar_system")]
 fn solar_system(r: &mut RanimScene) {
     // Setup camera looking down from above (top-down view)
     let phi = 50.0f64.to_radians(); // Small angle from +Z axis (almost straight down)

--- a/examples/test/lib.rs
+++ b/examples/test/lib.rs
@@ -24,7 +24,7 @@ use ranim::{
 // const SVG: &str = include_str!("../../assets/Ghostscript_Tiger.svg");
 
 #[scene]
-#[output(save_frames = true, dir = "output")]
+#[output(save_frames = true, dir = "./output/output")]
 fn test(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default().with(|x| {
         x.perspective_blend = 1.0;

--- a/examples/tetrahedron_spheres/lib.rs
+++ b/examples/tetrahedron_spheres/lib.rs
@@ -29,7 +29,7 @@ impl Eval<Surface> for RotateAroundZ {
 }
 
 #[scene]
-#[output(dir = "tetrahedron_spheres")]
+#[output(dir = "./output/tetrahedron_spheres")]
 fn tetrahedron_spheres(r: &mut RanimScene) {
     let phi = 60.0 * PI / 180.0;
     let theta = PI / 2.0;

--- a/examples/text_item/lib.rs
+++ b/examples/text_item/lib.rs
@@ -9,7 +9,7 @@ use ranim_anims::{
 use ranim_items::vitem::{VItem, text::TextItem};
 
 #[scene]
-#[output(dir = "text_item")]
+#[output(dir = "./output/text_item")]
 fn text_item(r: &mut RanimScene) {
     let _r_cam = r.insert(CameraFrame::default());
     let text = "The quick brown fox jumps over the lazy dog.";

--- a/packages/ranim-cli/src/cli/preview.rs
+++ b/packages/ranim-cli/src/cli/preview.rs
@@ -160,7 +160,7 @@ pub fn preview_command(args: &CliArgs, scene_name: &Option<String>) -> Result<()
     //     info!("- {:?}", scene.name);
     // }
     // panic!("Failed to get preview scene");
-    let mut app = RanimPreviewApp::new(scene.constructor, scene.name.clone());
+    let mut app = RanimPreviewApp::new(scene.constructor, scene.name.clone(), scene.config.clone());
     app.set_clear_color_str(&scene.config.clear_color);
     let cmd_tx = app.cmd_tx.clone();
 

--- a/packages/ranim-cli/src/cli/preview.rs
+++ b/packages/ranim-cli/src/cli/preview.rs
@@ -160,7 +160,7 @@ pub fn preview_command(args: &CliArgs, scene_name: &Option<String>) -> Result<()
     //     info!("- {:?}", scene.name);
     // }
     // panic!("Failed to get preview scene");
-    let mut app = RanimPreviewApp::new(scene.constructor, scene.name.clone(), scene.config.clone());
+    let mut app = RanimPreviewApp::new(scene.constructor, scene.name.clone());
     app.set_clear_color_str(&scene.config.clear_color);
     let cmd_tx = app.cmd_tx.clone();
 

--- a/packages/ranim-macros/src/scene.rs
+++ b/packages/ranim-macros/src/scene.rs
@@ -61,7 +61,7 @@ pub fn parse_output_list(list: &MetaList) -> syn::Result<OutputDef> {
         fps: 60,
         save_frames: false,
         name: None,
-        dir: "./".into(),
+        dir: "./output".into(),
         format: None,
     };
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,7 +2,7 @@
 #[cfg(all(not(target_family = "wasm"), feature = "render"))]
 pub mod render;
 #[cfg(all(not(target_family = "wasm"), feature = "render"))]
-pub use render::{render_scene, render_scene_output};
+pub use render::{render_scene, render_scene_output, render_scene_output_with_progress};
 
 /// Render a scene by name.
 ///

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -52,6 +52,8 @@ pub enum RanimPreviewAppCmd {
 }
 
 enum ExportProgress {
+    /// (current_frame, total_frames)
+    Progress(u64, u64),
     Done,
     Error(String),
 }
@@ -152,6 +154,8 @@ pub struct RanimPreviewApp {
     export_dialog_open: bool,
     export_config: Output,
     export_progress_rx: Option<Receiver<ExportProgress>>,
+    export_current_frame: u64,
+    export_total_frames: u64,
 
     // Playback
     playback_speed: f64,
@@ -201,6 +205,8 @@ impl RanimPreviewApp {
             export_dialog_open: false,
             export_config: Output::default(),
             export_progress_rx: None,
+            export_current_frame: 0,
+            export_total_frames: 0,
             playback_speed: 1.0,
             looping: false,
         }
@@ -447,13 +453,19 @@ impl RanimPreviewApp {
         let name = self.title.clone();
 
         std::thread::spawn(move || {
+            let progress_tx_cb = progress_tx.clone();
+            let ctx_cb = ctx.clone();
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                crate::cmd::render::render_scene_output(
+                crate::cmd::render::render_scene_output_with_progress(
                     constructor,
                     name,
                     &scene_config,
                     &output,
                     2,
+                    Some(Box::new(move |current, total| {
+                        let _ = progress_tx_cb.send_blocking(ExportProgress::Progress(current, total));
+                        ctx_cb.request_repaint();
+                    })),
                 );
 
                 let _ = progress_tx.send_blocking(ExportProgress::Done);
@@ -861,6 +873,10 @@ impl eframe::App for RanimPreviewApp {
 
             while let Ok(msg) = rx.try_recv() {
                 match msg {
+                    ExportProgress::Progress(current, total) => {
+                        self.export_current_frame = current;
+                        self.export_total_frames = total;
+                    }
                     ExportProgress::Done => {
                         done = true;
                     }
@@ -873,6 +889,8 @@ impl eframe::App for RanimPreviewApp {
 
             if done {
                 self.export_progress_rx = None;
+                self.export_current_frame = 0;
+                self.export_total_frames = 0;
                 if let Some(err) = error_msg {
                     error!("Export failed: {err}");
                 } else {
@@ -883,10 +901,20 @@ impl eframe::App for RanimPreviewApp {
                     .collapsible(false)
                     .resizable(false)
                     .show(ctx, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.spinner();
-                            ui.label("Rendering video...");
-                        });
+                        let current = self.export_current_frame;
+                        let total = self.export_total_frames;
+                        if total > 0 {
+                            let progress = current as f32 / total as f32;
+                            ui.add(egui::ProgressBar::new(progress).text(format!(
+                                "{current}/{total} frames ({:.0}%)",
+                                progress * 100.0
+                            )));
+                        } else {
+                            ui.horizontal(|ui| {
+                                ui.spinner();
+                                ui.label("Preparing...");
+                            });
+                        }
                     });
                 ctx.request_repaint();
             }

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -3,6 +3,7 @@ mod timeline;
 
 use crate::{
     Output, OutputFormat, Scene, SceneConfig, SceneConstructor,
+    cmd::render::file_writer::OutputFormatExt,
     core::{
         SealedRanimScene,
         color::{self, LinearSrgb},
@@ -163,7 +164,11 @@ pub struct RanimPreviewApp {
 }
 
 impl RanimPreviewApp {
-    pub fn new(scene_constructor: fn(&mut crate::core::RanimScene), title: String, scene_config: SceneConfig) -> Self {
+    pub fn new(
+        scene_constructor: fn(&mut crate::core::RanimScene),
+        title: String,
+        scene_config: SceneConfig,
+    ) -> Self {
         let t = Instant::now();
         info!("building scene...");
         let timeline = scene_constructor.build_scene();
@@ -463,7 +468,8 @@ impl RanimPreviewApp {
                     &output,
                     2,
                     Some(Box::new(move |current, total| {
-                        let _ = progress_tx_cb.send_blocking(ExportProgress::Progress(current, total));
+                        let _ =
+                            progress_tx_cb.send_blocking(ExportProgress::Progress(current, total));
                         ctx_cb.request_repaint();
                     })),
                 );
@@ -514,8 +520,8 @@ impl eframe::App for RanimPreviewApp {
             }
             if ctx.input(|i| i.key_pressed(egui::Key::ArrowRight)) {
                 self.play_prev_t = None;
-                self.timeline_state.current_sec =
-                    (self.timeline_state.current_sec + frame_dur).min(self.timeline_state.total_sec);
+                self.timeline_state.current_sec = (self.timeline_state.current_sec + frame_dur)
+                    .min(self.timeline_state.total_sec);
             }
         }
 
@@ -647,7 +653,10 @@ impl eframe::App for RanimPreviewApp {
 
                     ui.separator();
                     let exporting = self.export_progress_rx.is_some();
-                    if ui.add_enabled(!exporting, egui::Button::new("Export")).clicked() {
+                    if ui
+                        .add_enabled(!exporting, egui::Button::new("Export"))
+                        .clicked()
+                    {
                         self.export_dialog_open = true;
                     }
 
@@ -685,7 +694,11 @@ impl eframe::App for RanimPreviewApp {
                     }
 
                     // < Step back one frame
-                    if ui.button("⏪").on_hover_text("Step back one frame").clicked() {
+                    if ui
+                        .button("⏪")
+                        .on_hover_text("Step back one frame")
+                        .clicked()
+                    {
                         self.play_prev_t = None;
                         self.timeline_state.current_sec =
                             (self.timeline_state.current_sec - frame_dur).max(0.0);
@@ -707,10 +720,15 @@ impl eframe::App for RanimPreviewApp {
                     }
 
                     // > Step forward one frame
-                    if ui.button("⏩").on_hover_text("Step forward one frame").clicked() {
+                    if ui
+                        .button("⏩")
+                        .on_hover_text("Step forward one frame")
+                        .clicked()
+                    {
                         self.play_prev_t = None;
-                        self.timeline_state.current_sec =
-                            (self.timeline_state.current_sec + frame_dur).min(self.timeline_state.total_sec);
+                        self.timeline_state.current_sec = (self.timeline_state.current_sec
+                            + frame_dur)
+                            .min(self.timeline_state.total_sec);
                     }
 
                     // >| Jump to end
@@ -727,7 +745,15 @@ impl eframe::App for RanimPreviewApp {
                     if self.looping {
                         loop_btn = loop_btn.fill(ui.visuals().selection.bg_fill);
                     }
-                    if ui.add(loop_btn).on_hover_text(if self.looping { "Looping: ON" } else { "Looping: OFF" }).clicked() {
+                    if ui
+                        .add(loop_btn)
+                        .on_hover_text(if self.looping {
+                            "Looping: ON"
+                        } else {
+                            "Looping: OFF"
+                        })
+                        .clicked()
+                    {
                         self.looping = !self.looping;
                     }
 
@@ -740,7 +766,8 @@ impl eframe::App for RanimPreviewApp {
                             .speed(drag_speed)
                             .range(0.1..=10.0)
                             .suffix("x"),
-                    ).on_hover_text("Playback speed");
+                    )
+                    .on_hover_text("Playback speed");
 
                     ui.separator();
 
@@ -790,83 +817,7 @@ impl eframe::App for RanimPreviewApp {
             }
         });
 
-        // Export configuration dialog
-        if self.export_dialog_open {
-            let mut open = self.export_dialog_open;
-            egui::Window::new("Export")
-                .open(&mut open)
-                .resizable(false)
-                .show(ctx, |ui| {
-                    egui::Grid::new("export_grid").num_columns(2).show(ui, |ui| {
-                        ui.label("Width:");
-                        ui.add(egui::DragValue::new(&mut self.export_config.width).range(1..=7680));
-                        ui.end_row();
-
-                        ui.label("Height:");
-                        ui.add(egui::DragValue::new(&mut self.export_config.height).range(1..=4320));
-                        ui.end_row();
-
-                        ui.label("FPS:");
-                        ui.add(egui::DragValue::new(&mut self.export_config.fps).range(1..=240));
-                        ui.end_row();
-
-                        ui.label("Format:");
-                        egui::ComboBox::from_id_salt("export_format")
-                            .selected_text(format!("{}", self.export_config.format))
-                            .show_ui(ui, |ui| {
-                                ui.selectable_value(&mut self.export_config.format, OutputFormat::Mp4, "mp4");
-                                ui.selectable_value(&mut self.export_config.format, OutputFormat::Webm, "webm");
-                                ui.selectable_value(&mut self.export_config.format, OutputFormat::Mov, "mov");
-                                ui.selectable_value(&mut self.export_config.format, OutputFormat::Gif, "gif");
-                            });
-                        ui.end_row();
-
-                        ui.label("Output dir:");
-                        ui.text_edit_singleline(&mut self.export_config.dir);
-                        ui.end_row();
-
-                        ui.label("Save frames:");
-                        ui.checkbox(&mut self.export_config.save_frames, "");
-                        ui.end_row();
-                    });
-
-                    ui.add_space(8.0);
-
-                    // Show resolved output path preview
-                    {
-                        let mut output_dir = std::path::PathBuf::from(&self.export_config.dir);
-                        if !output_dir.is_absolute() {
-                            output_dir = std::env::current_dir()
-                                .unwrap_or_default()
-                                .join("output")
-                                .join(&output_dir);
-                        }
-                        let (_, _, ext) = self.export_config.format.encoding_params();
-                        let name = self.export_config.name.as_deref().unwrap_or(&self.title);
-                        let file_path = output_dir.join(format!(
-                            "{}_{}x{}_{}.{ext}",
-                            name,
-                            self.export_config.width,
-                            self.export_config.height,
-                            self.export_config.fps,
-                        ));
-                        ui.label(
-                            egui::RichText::new(format!("→ {}", file_path.display()))
-                                .small()
-                                .color(ui.visuals().weak_text_color()),
-                        );
-                    }
-
-                    ui.add_space(4.0);
-                    if ui.button("Start Export").clicked() {
-                        self.start_export(ctx.clone());
-                        self.export_dialog_open = false;
-                    }
-                });
-            self.export_dialog_open = open;
-        }
-
-        // Export progress dialog
+        // Poll export progress
         if let Some(rx) = &self.export_progress_rx {
             let mut done = false;
             let mut error_msg = None;
@@ -897,10 +848,110 @@ impl eframe::App for RanimPreviewApp {
                     info!("Export completed");
                 }
             } else {
-                egui::Window::new("Exporting...")
-                    .collapsible(false)
-                    .resizable(false)
-                    .show(ctx, |ui| {
+                ctx.request_repaint();
+            }
+        }
+
+        // Export configuration dialog
+        let exporting = self.export_progress_rx.is_some();
+        if self.export_dialog_open || exporting {
+            let mut open = self.export_dialog_open;
+            egui::Window::new("Export")
+                .open(&mut open)
+                .resizable(false)
+                .show(ctx, |ui| {
+                    ui.add_enabled_ui(!exporting, |ui| {
+                    egui::Grid::new("export_grid")
+                        .num_columns(2)
+                        .show(ui, |ui| {
+                            ui.label("Width:");
+                            ui.add(
+                                egui::DragValue::new(&mut self.export_config.width).range(1..=7680),
+                            );
+                            ui.end_row();
+
+                            ui.label("Height:");
+                            ui.add(
+                                egui::DragValue::new(&mut self.export_config.height)
+                                    .range(1..=4320),
+                            );
+                            ui.end_row();
+
+                            ui.label("FPS:");
+                            ui.add(
+                                egui::DragValue::new(&mut self.export_config.fps).range(1..=240),
+                            );
+                            ui.end_row();
+
+                            ui.label("Format:");
+                            egui::ComboBox::from_id_salt("export_format")
+                                .selected_text(format!("{}", self.export_config.format))
+                                .show_ui(ui, |ui| {
+                                    ui.selectable_value(
+                                        &mut self.export_config.format,
+                                        OutputFormat::Mp4,
+                                        "mp4",
+                                    );
+                                    ui.selectable_value(
+                                        &mut self.export_config.format,
+                                        OutputFormat::Webm,
+                                        "webm",
+                                    );
+                                    ui.selectable_value(
+                                        &mut self.export_config.format,
+                                        OutputFormat::Mov,
+                                        "mov",
+                                    );
+                                    ui.selectable_value(
+                                        &mut self.export_config.format,
+                                        OutputFormat::Gif,
+                                        "gif",
+                                    );
+                                });
+                            ui.end_row();
+
+                            ui.label("Output dir:");
+                            ui.text_edit_singleline(&mut self.export_config.dir);
+                            ui.end_row();
+
+                            // Show resolved output path preview right below the dir input
+                            ui.label("");
+                            {
+                                let mut output_dir =
+                                    std::path::PathBuf::from(&self.export_config.dir);
+                                if !output_dir.is_absolute() {
+                                    output_dir = std::env::current_dir()
+                                        .unwrap_or_default()
+                                        .join(&output_dir);
+                                }
+                                let (_, _, ext) = self.export_config.format.encoding_params();
+                                let name =
+                                    self.export_config.name.as_deref().unwrap_or(&self.title);
+                                let file_path = output_dir.join(format!(
+                                    "{}_{}x{}_{}.{ext}",
+                                    name,
+                                    self.export_config.width,
+                                    self.export_config.height,
+                                    self.export_config.fps,
+                                ));
+                                ui.label(
+                                    egui::RichText::new(format!("-> {}", file_path.display()))
+                                        .small()
+                                        .color(ui.visuals().weak_text_color()),
+                                );
+                            }
+                            ui.end_row();
+
+                            ui.label("Save frames:");
+                            ui.checkbox(&mut self.export_config.save_frames, "");
+                            ui.end_row();
+                        });
+                    }); // end add_enabled_ui
+
+                    ui.add_space(8.0);
+
+                    // Show progress bar inline when exporting
+                    if exporting {
                         let current = self.export_current_frame;
                         let total = self.export_total_frames;
                         if total > 0 {
@@ -915,8 +966,13 @@ impl eframe::App for RanimPreviewApp {
                                 ui.label("Preparing...");
                             });
                         }
-                    });
-                ctx.request_repaint();
+                    } else if ui.button("Start Export").clicked() {
+                        self.start_export(ctx.clone());
+                    }
+                });
+            // Don't allow closing the window while exporting
+            if !exporting {
+                self.export_dialog_open = open;
             }
         }
     }
@@ -978,7 +1034,11 @@ pub fn run_app(app: RanimPreviewApp, #[cfg(target_arch = "wasm32")] container_id
     }
 }
 
-pub fn preview_constructor_with_name(scene: fn(&mut crate::core::RanimScene), name: &str, scene_config: &SceneConfig) {
+pub fn preview_constructor_with_name(
+    scene: fn(&mut crate::core::RanimScene),
+    name: &str,
+    scene_config: &SceneConfig,
+) {
     let app = RanimPreviewApp::new(scene, name.to_string(), scene_config.clone());
     run_app(
         app,

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -819,6 +819,33 @@ impl eframe::App for RanimPreviewApp {
                     });
 
                     ui.add_space(8.0);
+
+                    // Show resolved output path preview
+                    {
+                        let mut output_dir = std::path::PathBuf::from(&self.export_config.dir);
+                        if !output_dir.is_absolute() {
+                            output_dir = std::env::current_dir()
+                                .unwrap_or_default()
+                                .join("output")
+                                .join(&output_dir);
+                        }
+                        let (_, _, ext) = self.export_config.format.encoding_params();
+                        let name = self.export_config.name.as_deref().unwrap_or(&self.title);
+                        let file_path = output_dir.join(format!(
+                            "{}_{}x{}_{}.{ext}",
+                            name,
+                            self.export_config.width,
+                            self.export_config.height,
+                            self.export_config.fps,
+                        ));
+                        ui.label(
+                            egui::RichText::new(format!("→ {}", file_path.display()))
+                                .small()
+                                .color(ui.visuals().weak_text_color()),
+                        );
+                    }
+
+                    ui.add_space(4.0);
                     if ui.button("Start Export").clicked() {
                         self.start_export(ctx.clone());
                         self.export_dialog_open = false;

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -2,8 +2,7 @@ mod depth_visual;
 mod timeline;
 
 use crate::{
-    Output, OutputFormat, Scene, SceneConfig, SceneConstructor,
-    cmd::render::file_writer::OutputFormatExt,
+    Output, Scene, SceneConfig, SceneConstructor,
     core::{
         SealedRanimScene,
         color::{self, LinearSrgb},
@@ -15,6 +14,8 @@ use crate::{
         utils::WgpuContext,
     },
 };
+#[cfg(all(not(target_family = "wasm"), feature = "render"))]
+use crate::{OutputFormat, cmd::render::file_writer::OutputFormatExt};
 use async_channel::{Receiver, Sender, unbounded};
 use depth_visual::DepthVisualPipeline;
 use eframe::egui;
@@ -52,6 +53,7 @@ pub enum RanimPreviewAppCmd {
     ReloadScene(Scene, Sender<()>),
 }
 
+#[cfg(all(not(target_family = "wasm"), feature = "render"))]
 enum ExportProgress {
     /// (current_frame, total_frames)
     Progress(u64, u64),
@@ -152,10 +154,14 @@ pub struct RanimPreviewApp {
     resolution_dirty: bool,
 
     // Export
+    #[cfg(all(not(target_family = "wasm"), feature = "render"))]
     export_dialog_open: bool,
     export_config: Output,
+    #[cfg(all(not(target_family = "wasm"), feature = "render"))]
     export_progress_rx: Option<Receiver<ExportProgress>>,
+    #[cfg(all(not(target_family = "wasm"), feature = "render"))]
     export_current_frame: u64,
+    #[cfg(all(not(target_family = "wasm"), feature = "render"))]
     export_total_frames: u64,
 
     // Playback
@@ -207,10 +213,14 @@ impl RanimPreviewApp {
             depth_visual_texture: None,
             depth_visual_view: None,
             resolution_dirty: false,
+            #[cfg(all(not(target_family = "wasm"), feature = "render"))]
             export_dialog_open: false,
             export_config: Output::default(),
+            #[cfg(all(not(target_family = "wasm"), feature = "render"))]
             export_progress_rx: None,
+            #[cfg(all(not(target_family = "wasm"), feature = "render"))]
             export_current_frame: 0,
+            #[cfg(all(not(target_family = "wasm"), feature = "render"))]
             export_total_frames: 0,
             playback_speed: 1.0,
             looping: false,
@@ -447,7 +457,7 @@ impl RanimPreviewApp {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(not(target_family = "wasm"), feature = "render"))]
     fn start_export(&mut self, ctx: egui::Context) {
         let (progress_tx, progress_rx) = unbounded();
         self.export_progress_rx = Some(progress_rx);
@@ -656,15 +666,17 @@ impl eframe::App for RanimPreviewApp {
                     }
 
                     ui.separator();
-                    let exporting = self.export_progress_rx.is_some();
-                    if ui
-                        .add_enabled(!exporting, egui::Button::new("Export"))
-                        .clicked()
+                    #[cfg(all(not(target_family = "wasm"), feature = "render"))]
                     {
-                        self.export_dialog_open = true;
+                        let exporting = self.export_progress_rx.is_some();
+                        if ui
+                            .add_enabled(!exporting, egui::Button::new("Export"))
+                            .clicked()
+                        {
+                            self.export_dialog_open = true;
+                        }
+                        ui.separator();
                     }
-
-                    ui.separator();
                     ui.selectable_value(&mut self.view_mode, ViewMode::Output, "Output");
                     ui.selectable_value(&mut self.view_mode, ViewMode::Depth, "Depth");
                     ui.separator();
@@ -832,171 +844,182 @@ impl eframe::App for RanimPreviewApp {
             }
         });
 
-        // Poll export progress
-        if let Some(rx) = &self.export_progress_rx {
-            let mut done = false;
-            let mut error_msg = None;
+        // Export (native only)
+        #[cfg(all(not(target_family = "wasm"), feature = "render"))]
+        {
+            // Poll export progress
+            if let Some(rx) = &self.export_progress_rx {
+                let mut done = false;
+                let mut error_msg = None;
 
-            while let Ok(msg) = rx.try_recv() {
-                match msg {
-                    ExportProgress::Progress(current, total) => {
-                        self.export_current_frame = current;
-                        self.export_total_frames = total;
-                    }
-                    ExportProgress::Done => {
-                        done = true;
-                    }
-                    ExportProgress::Error(err) => {
-                        error_msg = Some(err);
-                        done = true;
+                while let Ok(msg) = rx.try_recv() {
+                    match msg {
+                        ExportProgress::Progress(current, total) => {
+                            self.export_current_frame = current;
+                            self.export_total_frames = total;
+                        }
+                        ExportProgress::Done => {
+                            done = true;
+                        }
+                        ExportProgress::Error(err) => {
+                            error_msg = Some(err);
+                            done = true;
+                        }
                     }
                 }
-            }
 
-            if done {
-                self.export_progress_rx = None;
-                self.export_current_frame = 0;
-                self.export_total_frames = 0;
-                if let Some(err) = error_msg {
-                    error!("Export failed: {err}");
+                if done {
+                    self.export_progress_rx = None;
+                    self.export_current_frame = 0;
+                    self.export_total_frames = 0;
+                    if let Some(err) = error_msg {
+                        error!("Export failed: {err}");
+                    } else {
+                        info!("Export completed");
+                    }
                 } else {
-                    info!("Export completed");
+                    ctx.request_repaint();
                 }
-            } else {
-                ctx.request_repaint();
             }
-        }
 
-        // Export configuration dialog
-        let exporting = self.export_progress_rx.is_some();
-        if self.export_dialog_open || exporting {
-            let mut open = self.export_dialog_open;
-            egui::Window::new("Export")
-                .open(&mut open)
-                .resizable(false)
-                .show(ctx, |ui| {
-                    ui.add_enabled_ui(!exporting, |ui| {
-                        egui::Grid::new("export_grid")
-                            .num_columns(2)
-                            .show(ui, |ui| {
-                                ui.label("Width:");
-                                ui.add(
-                                    egui::DragValue::new(&mut self.export_config.width)
-                                        .range(1..=7680),
-                                );
-                                ui.end_row();
+            // Export configuration dialog
+            let exporting = self.export_progress_rx.is_some();
+            if self.export_dialog_open || exporting {
+                let mut open = self.export_dialog_open;
+                egui::Window::new("Export")
+                    .open(&mut open)
+                    .resizable(false)
+                    .show(ctx, |ui| {
+                        ui.add_enabled_ui(!exporting, |ui| {
+                            egui::Grid::new("export_grid")
+                                .num_columns(2)
+                                .show(ui, |ui| {
+                                    ui.label("Width:");
+                                    ui.add(
+                                        egui::DragValue::new(&mut self.export_config.width)
+                                            .range(1..=7680),
+                                    );
+                                    ui.end_row();
 
-                                ui.label("Height:");
-                                ui.add(
-                                    egui::DragValue::new(&mut self.export_config.height)
-                                        .range(1..=4320),
-                                );
-                                ui.end_row();
+                                    ui.label("Height:");
+                                    ui.add(
+                                        egui::DragValue::new(&mut self.export_config.height)
+                                            .range(1..=4320),
+                                    );
+                                    ui.end_row();
 
-                                ui.label("FPS:");
-                                ui.add(
-                                    egui::DragValue::new(&mut self.export_config.fps)
-                                        .range(1..=240),
-                                );
-                                ui.end_row();
+                                    ui.label("FPS:");
+                                    ui.add(
+                                        egui::DragValue::new(&mut self.export_config.fps)
+                                            .range(1..=240),
+                                    );
+                                    ui.end_row();
 
-                                ui.label("Format:");
-                                egui::ComboBox::from_id_salt("export_format")
-                                    .selected_text(format!("{}", self.export_config.format))
-                                    .show_ui(ui, |ui| {
-                                        ui.selectable_value(
-                                            &mut self.export_config.format,
-                                            OutputFormat::Mp4,
-                                            "mp4",
-                                        );
-                                        ui.selectable_value(
-                                            &mut self.export_config.format,
-                                            OutputFormat::Webm,
-                                            "webm",
-                                        );
-                                        ui.selectable_value(
-                                            &mut self.export_config.format,
-                                            OutputFormat::Mov,
-                                            "mov",
-                                        );
-                                        ui.selectable_value(
-                                            &mut self.export_config.format,
-                                            OutputFormat::Gif,
-                                            "gif",
-                                        );
-                                    });
-                                ui.end_row();
+                                    ui.label("Format:");
+                                    egui::ComboBox::from_id_salt("export_format")
+                                        .selected_text(format!("{}", self.export_config.format))
+                                        .show_ui(ui, |ui| {
+                                            ui.selectable_value(
+                                                &mut self.export_config.format,
+                                                OutputFormat::Mp4,
+                                                "mp4",
+                                            );
+                                            ui.selectable_value(
+                                                &mut self.export_config.format,
+                                                OutputFormat::Webm,
+                                                "webm",
+                                            );
+                                            ui.selectable_value(
+                                                &mut self.export_config.format,
+                                                OutputFormat::Mov,
+                                                "mov",
+                                            );
+                                            ui.selectable_value(
+                                                &mut self.export_config.format,
+                                                OutputFormat::Gif,
+                                                "gif",
+                                            );
+                                        });
+                                    ui.end_row();
 
-                                ui.label("Output dir:");
-                                ui.text_edit_singleline(&mut self.export_config.dir);
-                                ui.end_row();
+                                    ui.label("Output dir:");
+                                    ui.text_edit_singleline(&mut self.export_config.dir);
+                                    ui.end_row();
 
-                                // Show resolved output path preview right below the dir input
-                                ui.label("");
-                                {
-                                    let mut output_dir =
-                                        std::path::PathBuf::from(&self.export_config.dir);
-                                    if !output_dir.is_absolute() {
-                                        output_dir = std::env::current_dir()
-                                            .unwrap_or_default()
-                                            .join(&output_dir);
-                                    }
-                                    let (_, _, ext) = self.export_config.format.encoding_params();
-                                    let name =
-                                        self.export_config.name.as_deref().unwrap_or(&self.title);
-                                    let file_path = output_dir.join(format!(
-                                        "{}_{}x{}_{}.{ext}",
-                                        name,
-                                        self.export_config.width,
-                                        self.export_config.height,
-                                        self.export_config.fps,
-                                    ));
-                                    ui.label(
-                                        egui::RichText::new(format!("-> {}", file_path.display()))
+                                    // Show resolved output path preview right below the dir input
+                                    ui.label("");
+                                    {
+                                        let mut output_dir =
+                                            std::path::PathBuf::from(&self.export_config.dir);
+                                        if !output_dir.is_absolute() {
+                                            output_dir = std::env::current_dir()
+                                                .unwrap_or_default()
+                                                .join(&output_dir);
+                                        }
+                                        let (_, _, ext) =
+                                            self.export_config.format.encoding_params();
+                                        let name = self
+                                            .export_config
+                                            .name
+                                            .as_deref()
+                                            .unwrap_or(&self.title);
+                                        let file_path = output_dir.join(format!(
+                                            "{}_{}x{}_{}.{ext}",
+                                            name,
+                                            self.export_config.width,
+                                            self.export_config.height,
+                                            self.export_config.fps,
+                                        ));
+                                        ui.label(
+                                            egui::RichText::new(format!(
+                                                "-> {}",
+                                                file_path.display()
+                                            ))
                                             .small()
                                             .color(ui.visuals().weak_text_color()),
-                                    );
-                                }
-                                ui.end_row();
+                                        );
+                                    }
+                                    ui.end_row();
 
-                                ui.label("Save frames:");
-                                ui.checkbox(&mut self.export_config.save_frames, "");
-                                ui.end_row();
-                            });
-                    }); // end add_enabled_ui
+                                    ui.label("Save frames:");
+                                    ui.checkbox(&mut self.export_config.save_frames, "");
+                                    ui.end_row();
+                                });
+                        }); // end add_enabled_ui
 
-                    ui.add_space(8.0);
+                        ui.add_space(8.0);
 
-                    // Show progress bar inline when exporting
-                    if exporting {
-                        let current = self.export_current_frame;
-                        let total = self.export_total_frames;
-                        if total > 0 {
-                            let progress = current as f32 / total as f32;
-                            ui.add(egui::ProgressBar::new(progress).text(format!(
-                                "{current}/{total} frames ({:.0}%)",
-                                progress * 100.0
-                            )));
-                        } else {
-                            ui.horizontal(|ui| {
-                                ui.spinner();
-                                ui.label("Preparing...");
-                            });
+                        // Show progress bar inline when exporting
+                        if exporting {
+                            let current = self.export_current_frame;
+                            let total = self.export_total_frames;
+                            if total > 0 {
+                                let progress = current as f32 / total as f32;
+                                ui.add(egui::ProgressBar::new(progress).text(format!(
+                                    "{current}/{total} frames ({:.0}%)",
+                                    progress * 100.0
+                                )));
+                            } else {
+                                ui.horizontal(|ui| {
+                                    ui.spinner();
+                                    ui.label("Preparing...");
+                                });
+                            }
+                        } else if ui.button("Start Export").clicked() {
+                            self.start_export(ctx.clone());
                         }
-                    } else if ui.button("Start Export").clicked() {
-                        self.start_export(ctx.clone());
-                    }
-                });
-            // Don't allow closing the window while exporting
-            if !exporting {
-                self.export_dialog_open = open;
+                    });
+                // Don't allow closing the window while exporting
+                if !exporting {
+                    self.export_dialog_open = open;
+                }
             }
         }
     }
 }
 
 pub fn run_app(app: RanimPreviewApp, #[cfg(target_arch = "wasm32")] container_id: String) {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     {
         let native_options = eframe::NativeOptions {
             viewport: egui::ViewportBuilder::default()

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -152,6 +152,10 @@ pub struct RanimPreviewApp {
     export_dialog_open: bool,
     export_config: Output,
     export_progress_rx: Option<Receiver<ExportProgress>>,
+
+    // Playback
+    playback_speed: f64,
+    looping: bool,
 }
 
 impl RanimPreviewApp {
@@ -197,6 +201,8 @@ impl RanimPreviewApp {
             export_dialog_open: false,
             export_config: Output::default(),
             export_progress_rx: None,
+            playback_speed: 1.0,
+            looping: false,
         }
     }
 
@@ -486,12 +492,33 @@ impl eframe::App for RanimPreviewApp {
             }
         }
 
+        // Arrow keys step forward/back one frame
+        {
+            let frame_dur = 1.0 / self.export_config.fps as f64;
+            if ctx.input(|i| i.key_pressed(egui::Key::ArrowLeft)) {
+                self.play_prev_t = None;
+                self.timeline_state.current_sec =
+                    (self.timeline_state.current_sec - frame_dur).max(0.0);
+            }
+            if ctx.input(|i| i.key_pressed(egui::Key::ArrowRight)) {
+                self.play_prev_t = None;
+                self.timeline_state.current_sec =
+                    (self.timeline_state.current_sec + frame_dur).min(self.timeline_state.total_sec);
+            }
+        }
+
         if let Some(play_prev_t) = self.play_prev_t {
-            let elapsed = play_prev_t.elapsed().as_secs_f64();
+            let elapsed = play_prev_t.elapsed().as_secs_f64() * self.playback_speed;
             self.timeline_state.current_sec =
                 (self.timeline_state.current_sec + elapsed).min(self.timeline_state.total_sec);
-            if self.timeline_state.current_sec == self.timeline_state.total_sec {
-                self.play_prev_t = None;
+            if self.timeline_state.current_sec >= self.timeline_state.total_sec {
+                if self.looping {
+                    self.timeline_state.current_sec = 0.0;
+                    self.play_prev_t = Some(Instant::now());
+                    ctx.request_repaint();
+                } else {
+                    self.play_prev_t = None;
+                }
             } else {
                 self.play_prev_t = Some(Instant::now());
                 ctx.request_repaint(); // Animation loop
@@ -636,25 +663,75 @@ impl eframe::App for RanimPreviewApp {
                 ui.label("Timeline");
 
                 ui.horizontal(|ui| {
-                    if ui.button("<<").clicked() {
+                    let fps = self.export_config.fps as f64;
+                    let frame_dur = 1.0 / fps;
+
+                    // |< Jump to start
+                    if ui.button("⏮").on_hover_text("Jump to start").clicked() {
                         self.timeline_state.current_sec = 0.0;
+                        self.play_prev_t = None;
                     }
-                    #[allow(clippy::collapsible_else_if)]
-                    if self.play_prev_t.is_none() {
-                        if ui.button("play").clicked() {
+
+                    // < Step back one frame
+                    if ui.button("⏪").on_hover_text("Step back one frame").clicked() {
+                        self.play_prev_t = None;
+                        self.timeline_state.current_sec =
+                            (self.timeline_state.current_sec - frame_dur).max(0.0);
+                    }
+
+                    // Play / Pause
+                    let is_playing = self.play_prev_t.is_some();
+                    let play_label = if is_playing { "⏸" } else { "▶" };
+                    let play_tooltip = if is_playing { "Pause" } else { "Play" };
+                    if ui.button(play_label).on_hover_text(play_tooltip).clicked() {
+                        if is_playing {
+                            self.play_prev_t = None;
+                        } else {
                             if self.timeline_state.current_sec >= self.timeline_state.total_sec {
                                 self.timeline_state.current_sec = 0.0;
                             }
                             self.play_prev_t = Some(Instant::now());
                         }
-                    } else {
-                        if ui.button("pause").clicked() {
-                            self.play_prev_t = None;
-                        }
                     }
-                    if ui.button(">>").clicked() {
+
+                    // > Step forward one frame
+                    if ui.button("⏩").on_hover_text("Step forward one frame").clicked() {
+                        self.play_prev_t = None;
+                        self.timeline_state.current_sec =
+                            (self.timeline_state.current_sec + frame_dur).min(self.timeline_state.total_sec);
+                    }
+
+                    // >| Jump to end
+                    if ui.button("⏭").on_hover_text("Jump to end").clicked() {
                         self.timeline_state.current_sec = self.timeline_state.total_sec;
+                        self.play_prev_t = None;
                     }
+
+                    ui.separator();
+
+                    // Loop toggle
+                    let loop_label = if self.looping { "🔁" } else { "🔁" };
+                    let mut loop_btn = egui::Button::new(loop_label);
+                    if self.looping {
+                        loop_btn = loop_btn.fill(ui.visuals().selection.bg_fill);
+                    }
+                    if ui.add(loop_btn).on_hover_text(if self.looping { "Looping: ON" } else { "Looping: OFF" }).clicked() {
+                        self.looping = !self.looping;
+                    }
+
+                    ui.separator();
+
+                    // Speed control
+                    let drag_speed = (self.playback_speed * 0.02).max(0.01);
+                    ui.add(
+                        egui::DragValue::new(&mut self.playback_speed)
+                            .speed(drag_speed)
+                            .range(0.1..=10.0)
+                            .suffix("x"),
+                    ).on_hover_text("Playback speed");
+
+                    ui.separator();
+
                     ui.style_mut().spacing.slider_width = ui.available_width() - 70.0;
                     ui.add(
                         egui::Slider::new(

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -2,7 +2,7 @@ mod depth_visual;
 mod timeline;
 
 use crate::{
-    Output, OutputFormat, Scene, SceneConstructor,
+    Output, OutputFormat, Scene, SceneConfig, SceneConstructor,
     cmd::render::file_writer::OutputFormatExt,
     core::{
         SealedRanimScene,
@@ -124,6 +124,7 @@ pub struct RanimPreviewApp {
     title: String,
     clear_color: wgpu::Color,
     scene_constructor: fn(&mut crate::core::RanimScene),
+    scene_config: SceneConfig,
     resolution: Resolution,
     timeline: SealedRanimScene,
     need_eval: bool,
@@ -168,6 +169,7 @@ impl RanimPreviewApp {
     pub fn new(
         scene_constructor: fn(&mut crate::core::RanimScene),
         title: String,
+        scene_config: SceneConfig,
     ) -> Self {
         let t = Instant::now();
         info!("building scene...");
@@ -186,6 +188,7 @@ impl RanimPreviewApp {
             title,
             clear_color: wgpu::Color::TRANSPARENT,
             scene_constructor,
+            scene_config,
             resolution: Resolution::QHD,
             timeline_state: TimelineState::new(timeline.total_secs(), timeline_infos),
             timeline,
@@ -456,7 +459,7 @@ impl RanimPreviewApp {
         self.export_cancel.store(false, Ordering::Relaxed);
 
         let constructor = self.scene_constructor;
-        let clear_color = self.clear_color;
+        let scene_config = self.scene_config.clone();
         let output = self.export_config.clone();
         let name = self.title.clone();
         let cancel = self.export_cancel.clone();
@@ -468,16 +471,15 @@ impl RanimPreviewApp {
                 let cancelled = crate::cmd::render::render_scene_output_with_progress(
                     constructor,
                     name,
-                    clear_color,
+                    &scene_config,
                     &output,
                     2,
                     Some(Box::new(move |current, total| {
                         let _ =
                             progress_tx_cb.send_blocking(ExportProgress::Progress(current, total));
                         ctx_cb.request_repaint();
-                        // Return false to cancel
-                        !cancel.load(Ordering::Relaxed)
                     })),
+                    Some(cancel),
                 );
 
                 if cancelled {
@@ -1054,8 +1056,9 @@ pub fn run_app(app: RanimPreviewApp, #[cfg(target_arch = "wasm32")] container_id
 pub fn preview_constructor_with_name(
     scene: fn(&mut crate::core::RanimScene),
     name: &str,
+    scene_config: &SceneConfig,
 ) {
-    let app = RanimPreviewApp::new(scene, name.to_string());
+    let app = RanimPreviewApp::new(scene, name.to_string(), scene_config.clone());
     run_app(
         app,
         #[cfg(target_arch = "wasm32")]
@@ -1070,7 +1073,7 @@ pub fn preview_scene(scene: &Scene) {
 
 /// Preview a scene with a custom name
 pub fn preview_scene_with_name(scene: &Scene, name: &str) {
-    let mut app = RanimPreviewApp::new(scene.constructor, name.to_string());
+    let mut app = RanimPreviewApp::new(scene.constructor, name.to_string(), scene.config.clone());
     app.set_clear_color_str(&scene.config.clear_color);
     run_app(
         app,

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -2,7 +2,7 @@ mod depth_visual;
 mod timeline;
 
 use crate::{
-    Scene, SceneConstructor,
+    Output, OutputFormat, Scene, SceneConfig, SceneConstructor,
     core::{
         SealedRanimScene,
         color::{self, LinearSrgb},
@@ -49,6 +49,11 @@ impl TimelineInfoState {
 
 pub enum RanimPreviewAppCmd {
     ReloadScene(Scene, Sender<()>),
+}
+
+enum ExportProgress {
+    Done,
+    Error(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -114,6 +119,8 @@ pub struct RanimPreviewApp {
     #[allow(unused)]
     title: String,
     clear_color: wgpu::Color,
+    scene_constructor: fn(&mut crate::core::RanimScene),
+    scene_config: SceneConfig,
     resolution: Resolution,
     timeline: SealedRanimScene,
     need_eval: bool,
@@ -140,10 +147,15 @@ pub struct RanimPreviewApp {
 
     // Resolution changed flag
     resolution_dirty: bool,
+
+    // Export
+    export_dialog_open: bool,
+    export_config: Output,
+    export_progress_rx: Option<Receiver<ExportProgress>>,
 }
 
 impl RanimPreviewApp {
-    pub fn new(scene_constructor: impl SceneConstructor, title: String) -> Self {
+    pub fn new(scene_constructor: fn(&mut crate::core::RanimScene), title: String, scene_config: SceneConfig) -> Self {
         let t = Instant::now();
         info!("building scene...");
         let timeline = scene_constructor.build_scene();
@@ -160,6 +172,8 @@ impl RanimPreviewApp {
             cmd_tx,
             title,
             clear_color: wgpu::Color::TRANSPARENT,
+            scene_constructor,
+            scene_config,
             resolution: Resolution::QHD,
             timeline_state: TimelineState::new(timeline.total_secs(), timeline_infos),
             timeline,
@@ -180,6 +194,9 @@ impl RanimPreviewApp {
             depth_visual_texture: None,
             depth_visual_view: None,
             resolution_dirty: false,
+            export_dialog_open: false,
+            export_config: Output::default(),
+            export_progress_rx: None,
         }
     }
 
@@ -412,12 +429,62 @@ impl RanimPreviewApp {
             self.pool.clean();
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn start_export(&mut self, ctx: egui::Context) {
+        let (progress_tx, progress_rx) = unbounded();
+        self.export_progress_rx = Some(progress_rx);
+
+        let constructor = self.scene_constructor;
+        let scene_config = self.scene_config.clone();
+        let output = self.export_config.clone();
+        let name = self.title.clone();
+
+        std::thread::spawn(move || {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                crate::cmd::render::render_scene_output(
+                    constructor,
+                    name,
+                    &scene_config,
+                    &output,
+                    2,
+                );
+
+                let _ = progress_tx.send_blocking(ExportProgress::Done);
+                ctx.request_repaint();
+            }));
+
+            if let Err(e) = result {
+                let msg = if let Some(s) = e.downcast_ref::<&str>() {
+                    s.to_string()
+                } else if let Some(s) = e.downcast_ref::<String>() {
+                    s.clone()
+                } else {
+                    "Unknown export error".to_string()
+                };
+                let _ = progress_tx.send_blocking(ExportProgress::Error(msg));
+                ctx.request_repaint();
+            }
+        });
+    }
 }
 
 impl eframe::App for RanimPreviewApp {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         self.prepare_renderer(frame);
         self.handle_events();
+
+        // Space bar toggles play/pause
+        if ctx.input(|i| i.key_pressed(egui::Key::Space)) {
+            if self.play_prev_t.is_some() {
+                self.play_prev_t = None;
+            } else {
+                if self.timeline_state.current_sec >= self.timeline_state.total_sec {
+                    self.timeline_state.current_sec = 0.0;
+                }
+                self.play_prev_t = Some(Instant::now());
+            }
+        }
 
         if let Some(play_prev_t) = self.play_prev_t {
             let elapsed = play_prev_t.elapsed().as_secs_f64();
@@ -540,6 +607,12 @@ impl eframe::App for RanimPreviewApp {
                     }
 
                     ui.separator();
+                    let exporting = self.export_progress_rx.is_some();
+                    if ui.add_enabled(!exporting, egui::Button::new("Export")).clicked() {
+                        self.export_dialog_open = true;
+                    }
+
+                    ui.separator();
                     ui.selectable_value(&mut self.view_mode, ViewMode::Output, "Output");
                     ui.selectable_value(&mut self.view_mode, ViewMode::Depth, "Depth");
                     ui.separator();
@@ -569,6 +642,9 @@ impl eframe::App for RanimPreviewApp {
                     #[allow(clippy::collapsible_else_if)]
                     if self.play_prev_t.is_none() {
                         if ui.button("play").clicked() {
+                            if self.timeline_state.current_sec >= self.timeline_state.total_sec {
+                                self.timeline_state.current_sec = 0.0;
+                            }
                             self.play_prev_t = Some(Instant::now());
                         }
                     } else {
@@ -624,6 +700,93 @@ impl eframe::App for RanimPreviewApp {
                 });
             }
         });
+
+        // Export configuration dialog
+        if self.export_dialog_open {
+            let mut open = self.export_dialog_open;
+            egui::Window::new("Export")
+                .open(&mut open)
+                .resizable(false)
+                .show(ctx, |ui| {
+                    egui::Grid::new("export_grid").num_columns(2).show(ui, |ui| {
+                        ui.label("Width:");
+                        ui.add(egui::DragValue::new(&mut self.export_config.width).range(1..=7680));
+                        ui.end_row();
+
+                        ui.label("Height:");
+                        ui.add(egui::DragValue::new(&mut self.export_config.height).range(1..=4320));
+                        ui.end_row();
+
+                        ui.label("FPS:");
+                        ui.add(egui::DragValue::new(&mut self.export_config.fps).range(1..=240));
+                        ui.end_row();
+
+                        ui.label("Format:");
+                        egui::ComboBox::from_id_salt("export_format")
+                            .selected_text(format!("{}", self.export_config.format))
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(&mut self.export_config.format, OutputFormat::Mp4, "mp4");
+                                ui.selectable_value(&mut self.export_config.format, OutputFormat::Webm, "webm");
+                                ui.selectable_value(&mut self.export_config.format, OutputFormat::Mov, "mov");
+                                ui.selectable_value(&mut self.export_config.format, OutputFormat::Gif, "gif");
+                            });
+                        ui.end_row();
+
+                        ui.label("Output dir:");
+                        ui.text_edit_singleline(&mut self.export_config.dir);
+                        ui.end_row();
+
+                        ui.label("Save frames:");
+                        ui.checkbox(&mut self.export_config.save_frames, "");
+                        ui.end_row();
+                    });
+
+                    ui.add_space(8.0);
+                    if ui.button("Start Export").clicked() {
+                        self.start_export(ctx.clone());
+                        self.export_dialog_open = false;
+                    }
+                });
+            self.export_dialog_open = open;
+        }
+
+        // Export progress dialog
+        if let Some(rx) = &self.export_progress_rx {
+            let mut done = false;
+            let mut error_msg = None;
+
+            while let Ok(msg) = rx.try_recv() {
+                match msg {
+                    ExportProgress::Done => {
+                        done = true;
+                    }
+                    ExportProgress::Error(err) => {
+                        error_msg = Some(err);
+                        done = true;
+                    }
+                }
+            }
+
+            if done {
+                self.export_progress_rx = None;
+                if let Some(err) = error_msg {
+                    error!("Export failed: {err}");
+                } else {
+                    info!("Export completed");
+                }
+            } else {
+                egui::Window::new("Exporting...")
+                    .collapsible(false)
+                    .resizable(false)
+                    .show(ctx, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.spinner();
+                            ui.label("Rendering video...");
+                        });
+                    });
+                ctx.request_repaint();
+            }
+        }
     }
 }
 
@@ -683,8 +846,8 @@ pub fn run_app(app: RanimPreviewApp, #[cfg(target_arch = "wasm32")] container_id
     }
 }
 
-pub fn preview_constructor_with_name(scene: impl SceneConstructor, name: &str) {
-    let app = RanimPreviewApp::new(scene, name.to_string());
+pub fn preview_constructor_with_name(scene: fn(&mut crate::core::RanimScene), name: &str, scene_config: &SceneConfig) {
+    let app = RanimPreviewApp::new(scene, name.to_string(), scene_config.clone());
     run_app(
         app,
         #[cfg(target_arch = "wasm32")]
@@ -699,7 +862,7 @@ pub fn preview_scene(scene: &Scene) {
 
 /// Preview a scene with a custom name
 pub fn preview_scene_with_name(scene: &Scene, name: &str) {
-    let mut app = RanimPreviewApp::new(scene.constructor, name.to_string());
+    let mut app = RanimPreviewApp::new(scene.constructor, name.to_string(), scene.config.clone());
     app.set_clear_color_str(&scene.config.clear_color);
     run_app(
         app,

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -2,7 +2,7 @@ mod depth_visual;
 mod timeline;
 
 use crate::{
-    Output, OutputFormat, Scene, SceneConfig, SceneConstructor,
+    Output, OutputFormat, Scene, SceneConstructor,
     cmd::render::file_writer::OutputFormatExt,
     core::{
         SealedRanimScene,
@@ -56,6 +56,7 @@ enum ExportProgress {
     /// (current_frame, total_frames)
     Progress(u64, u64),
     Done,
+    Cancelled,
     Error(String),
 }
 
@@ -123,7 +124,6 @@ pub struct RanimPreviewApp {
     title: String,
     clear_color: wgpu::Color,
     scene_constructor: fn(&mut crate::core::RanimScene),
-    scene_config: SceneConfig,
     resolution: Resolution,
     timeline: SealedRanimScene,
     need_eval: bool,
@@ -155,6 +155,7 @@ pub struct RanimPreviewApp {
     export_dialog_open: bool,
     export_config: Output,
     export_progress_rx: Option<Receiver<ExportProgress>>,
+    export_cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
     export_current_frame: u64,
     export_total_frames: u64,
 
@@ -167,7 +168,6 @@ impl RanimPreviewApp {
     pub fn new(
         scene_constructor: fn(&mut crate::core::RanimScene),
         title: String,
-        scene_config: SceneConfig,
     ) -> Self {
         let t = Instant::now();
         info!("building scene...");
@@ -186,7 +186,6 @@ impl RanimPreviewApp {
             title,
             clear_color: wgpu::Color::TRANSPARENT,
             scene_constructor,
-            scene_config,
             resolution: Resolution::QHD,
             timeline_state: TimelineState::new(timeline.total_secs(), timeline_infos),
             timeline,
@@ -210,6 +209,7 @@ impl RanimPreviewApp {
             export_dialog_open: false,
             export_config: Output::default(),
             export_progress_rx: None,
+            export_cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             export_current_frame: 0,
             export_total_frames: 0,
             playback_speed: 1.0,
@@ -449,32 +449,42 @@ impl RanimPreviewApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn start_export(&mut self, ctx: egui::Context) {
+        use std::sync::atomic::Ordering;
+
         let (progress_tx, progress_rx) = unbounded();
         self.export_progress_rx = Some(progress_rx);
+        self.export_cancel.store(false, Ordering::Relaxed);
 
         let constructor = self.scene_constructor;
-        let scene_config = self.scene_config.clone();
+        let clear_color = self.clear_color;
         let output = self.export_config.clone();
         let name = self.title.clone();
+        let cancel = self.export_cancel.clone();
 
         std::thread::spawn(move || {
             let progress_tx_cb = progress_tx.clone();
             let ctx_cb = ctx.clone();
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                crate::cmd::render::render_scene_output_with_progress(
+                let cancelled = crate::cmd::render::render_scene_output_with_progress(
                     constructor,
                     name,
-                    &scene_config,
+                    clear_color,
                     &output,
                     2,
                     Some(Box::new(move |current, total| {
                         let _ =
                             progress_tx_cb.send_blocking(ExportProgress::Progress(current, total));
                         ctx_cb.request_repaint();
+                        // Return false to cancel
+                        !cancel.load(Ordering::Relaxed)
                     })),
                 );
 
-                let _ = progress_tx.send_blocking(ExportProgress::Done);
+                if cancelled {
+                    let _ = progress_tx.send_blocking(ExportProgress::Cancelled);
+                } else {
+                    let _ = progress_tx.send_blocking(ExportProgress::Done);
+                }
                 ctx.request_repaint();
             }));
 
@@ -831,6 +841,9 @@ impl eframe::App for RanimPreviewApp {
                     ExportProgress::Done => {
                         done = true;
                     }
+                    ExportProgress::Cancelled => {
+                        done = true;
+                    }
                     ExportProgress::Error(err) => {
                         error_msg = Some(err);
                         done = true;
@@ -966,6 +979,10 @@ impl eframe::App for RanimPreviewApp {
                                 ui.label("Preparing...");
                             });
                         }
+                        if ui.button("Cancel").clicked() {
+                            self.export_cancel
+                                .store(true, std::sync::atomic::Ordering::Relaxed);
+                        }
                     } else if ui.button("Start Export").clicked() {
                         self.start_export(ctx.clone());
                     }
@@ -1037,9 +1054,8 @@ pub fn run_app(app: RanimPreviewApp, #[cfg(target_arch = "wasm32")] container_id
 pub fn preview_constructor_with_name(
     scene: fn(&mut crate::core::RanimScene),
     name: &str,
-    scene_config: &SceneConfig,
 ) {
-    let app = RanimPreviewApp::new(scene, name.to_string(), scene_config.clone());
+    let app = RanimPreviewApp::new(scene, name.to_string());
     run_app(
         app,
         #[cfg(target_arch = "wasm32")]
@@ -1054,7 +1070,7 @@ pub fn preview_scene(scene: &Scene) {
 
 /// Preview a scene with a custom name
 pub fn preview_scene_with_name(scene: &Scene, name: &str) {
-    let mut app = RanimPreviewApp::new(scene.constructor, name.to_string(), scene.config.clone());
+    let mut app = RanimPreviewApp::new(scene.constructor, name.to_string());
     app.set_clear_color_str(&scene.config.clear_color);
     run_app(
         app,

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -692,7 +692,11 @@ impl eframe::App for RanimPreviewApp {
                     let frame_dur = 1.0 / fps;
 
                     // |< Jump to start
-                    if ui.button(egui_phosphor::regular::SKIP_BACK).on_hover_text("Jump to start").clicked() {
+                    if ui
+                        .button(egui_phosphor::regular::SKIP_BACK)
+                        .on_hover_text("Jump to start")
+                        .clicked()
+                    {
                         self.timeline_state.current_sec = 0.0;
                         self.play_prev_t = None;
                     }
@@ -740,7 +744,11 @@ impl eframe::App for RanimPreviewApp {
                     }
 
                     // >| Jump to end
-                    if ui.button(egui_phosphor::regular::SKIP_FORWARD).on_hover_text("Jump to end").clicked() {
+                    if ui
+                        .button(egui_phosphor::regular::SKIP_FORWARD)
+                        .on_hover_text("Jump to end")
+                        .clicked()
+                    {
                         self.timeline_state.current_sec = self.timeline_state.total_sec;
                         self.play_prev_t = None;
                     }
@@ -868,91 +876,93 @@ impl eframe::App for RanimPreviewApp {
                 .resizable(false)
                 .show(ctx, |ui| {
                     ui.add_enabled_ui(!exporting, |ui| {
-                    egui::Grid::new("export_grid")
-                        .num_columns(2)
-                        .show(ui, |ui| {
-                            ui.label("Width:");
-                            ui.add(
-                                egui::DragValue::new(&mut self.export_config.width).range(1..=7680),
-                            );
-                            ui.end_row();
-
-                            ui.label("Height:");
-                            ui.add(
-                                egui::DragValue::new(&mut self.export_config.height)
-                                    .range(1..=4320),
-                            );
-                            ui.end_row();
-
-                            ui.label("FPS:");
-                            ui.add(
-                                egui::DragValue::new(&mut self.export_config.fps).range(1..=240),
-                            );
-                            ui.end_row();
-
-                            ui.label("Format:");
-                            egui::ComboBox::from_id_salt("export_format")
-                                .selected_text(format!("{}", self.export_config.format))
-                                .show_ui(ui, |ui| {
-                                    ui.selectable_value(
-                                        &mut self.export_config.format,
-                                        OutputFormat::Mp4,
-                                        "mp4",
-                                    );
-                                    ui.selectable_value(
-                                        &mut self.export_config.format,
-                                        OutputFormat::Webm,
-                                        "webm",
-                                    );
-                                    ui.selectable_value(
-                                        &mut self.export_config.format,
-                                        OutputFormat::Mov,
-                                        "mov",
-                                    );
-                                    ui.selectable_value(
-                                        &mut self.export_config.format,
-                                        OutputFormat::Gif,
-                                        "gif",
-                                    );
-                                });
-                            ui.end_row();
-
-                            ui.label("Output dir:");
-                            ui.text_edit_singleline(&mut self.export_config.dir);
-                            ui.end_row();
-
-                            // Show resolved output path preview right below the dir input
-                            ui.label("");
-                            {
-                                let mut output_dir =
-                                    std::path::PathBuf::from(&self.export_config.dir);
-                                if !output_dir.is_absolute() {
-                                    output_dir = std::env::current_dir()
-                                        .unwrap_or_default()
-                                        .join(&output_dir);
-                                }
-                                let (_, _, ext) = self.export_config.format.encoding_params();
-                                let name =
-                                    self.export_config.name.as_deref().unwrap_or(&self.title);
-                                let file_path = output_dir.join(format!(
-                                    "{}_{}x{}_{}.{ext}",
-                                    name,
-                                    self.export_config.width,
-                                    self.export_config.height,
-                                    self.export_config.fps,
-                                ));
-                                ui.label(
-                                    egui::RichText::new(format!("-> {}", file_path.display()))
-                                        .small()
-                                        .color(ui.visuals().weak_text_color()),
+                        egui::Grid::new("export_grid")
+                            .num_columns(2)
+                            .show(ui, |ui| {
+                                ui.label("Width:");
+                                ui.add(
+                                    egui::DragValue::new(&mut self.export_config.width)
+                                        .range(1..=7680),
                                 );
-                            }
-                            ui.end_row();
+                                ui.end_row();
 
-                            ui.label("Save frames:");
-                            ui.checkbox(&mut self.export_config.save_frames, "");
-                            ui.end_row();
-                        });
+                                ui.label("Height:");
+                                ui.add(
+                                    egui::DragValue::new(&mut self.export_config.height)
+                                        .range(1..=4320),
+                                );
+                                ui.end_row();
+
+                                ui.label("FPS:");
+                                ui.add(
+                                    egui::DragValue::new(&mut self.export_config.fps)
+                                        .range(1..=240),
+                                );
+                                ui.end_row();
+
+                                ui.label("Format:");
+                                egui::ComboBox::from_id_salt("export_format")
+                                    .selected_text(format!("{}", self.export_config.format))
+                                    .show_ui(ui, |ui| {
+                                        ui.selectable_value(
+                                            &mut self.export_config.format,
+                                            OutputFormat::Mp4,
+                                            "mp4",
+                                        );
+                                        ui.selectable_value(
+                                            &mut self.export_config.format,
+                                            OutputFormat::Webm,
+                                            "webm",
+                                        );
+                                        ui.selectable_value(
+                                            &mut self.export_config.format,
+                                            OutputFormat::Mov,
+                                            "mov",
+                                        );
+                                        ui.selectable_value(
+                                            &mut self.export_config.format,
+                                            OutputFormat::Gif,
+                                            "gif",
+                                        );
+                                    });
+                                ui.end_row();
+
+                                ui.label("Output dir:");
+                                ui.text_edit_singleline(&mut self.export_config.dir);
+                                ui.end_row();
+
+                                // Show resolved output path preview right below the dir input
+                                ui.label("");
+                                {
+                                    let mut output_dir =
+                                        std::path::PathBuf::from(&self.export_config.dir);
+                                    if !output_dir.is_absolute() {
+                                        output_dir = std::env::current_dir()
+                                            .unwrap_or_default()
+                                            .join(&output_dir);
+                                    }
+                                    let (_, _, ext) = self.export_config.format.encoding_params();
+                                    let name =
+                                        self.export_config.name.as_deref().unwrap_or(&self.title);
+                                    let file_path = output_dir.join(format!(
+                                        "{}_{}x{}_{}.{ext}",
+                                        name,
+                                        self.export_config.width,
+                                        self.export_config.height,
+                                        self.export_config.fps,
+                                    ));
+                                    ui.label(
+                                        egui::RichText::new(format!("-> {}", file_path.display()))
+                                            .small()
+                                            .color(ui.visuals().weak_text_color()),
+                                    );
+                                }
+                                ui.end_row();
+
+                                ui.label("Save frames:");
+                                ui.checkbox(&mut self.export_config.save_frames, "");
+                                ui.end_row();
+                            });
                     }); // end add_enabled_ui
 
                     ui.add_space(8.0);

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -56,7 +56,6 @@ enum ExportProgress {
     /// (current_frame, total_frames)
     Progress(u64, u64),
     Done,
-    Cancelled,
     Error(String),
 }
 
@@ -156,7 +155,6 @@ pub struct RanimPreviewApp {
     export_dialog_open: bool,
     export_config: Output,
     export_progress_rx: Option<Receiver<ExportProgress>>,
-    export_cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
     export_current_frame: u64,
     export_total_frames: u64,
 
@@ -212,7 +210,6 @@ impl RanimPreviewApp {
             export_dialog_open: false,
             export_config: Output::default(),
             export_progress_rx: None,
-            export_cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             export_current_frame: 0,
             export_total_frames: 0,
             playback_speed: 1.0,
@@ -452,23 +449,19 @@ impl RanimPreviewApp {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn start_export(&mut self, ctx: egui::Context) {
-        use std::sync::atomic::Ordering;
-
         let (progress_tx, progress_rx) = unbounded();
         self.export_progress_rx = Some(progress_rx);
-        self.export_cancel.store(false, Ordering::Relaxed);
 
         let constructor = self.scene_constructor;
         let scene_config = self.scene_config.clone();
         let output = self.export_config.clone();
         let name = self.title.clone();
-        let cancel = self.export_cancel.clone();
 
         std::thread::spawn(move || {
             let progress_tx_cb = progress_tx.clone();
             let ctx_cb = ctx.clone();
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let cancelled = crate::cmd::render::render_scene_output_with_progress(
+                crate::cmd::render::render_scene_output_with_progress(
                     constructor,
                     name,
                     &scene_config,
@@ -479,14 +472,9 @@ impl RanimPreviewApp {
                             progress_tx_cb.send_blocking(ExportProgress::Progress(current, total));
                         ctx_cb.request_repaint();
                     })),
-                    Some(cancel),
                 );
 
-                if cancelled {
-                    let _ = progress_tx.send_blocking(ExportProgress::Cancelled);
-                } else {
-                    let _ = progress_tx.send_blocking(ExportProgress::Done);
-                }
+                let _ = progress_tx.send_blocking(ExportProgress::Done);
                 ctx.request_repaint();
             }));
 
@@ -654,7 +642,11 @@ impl eframe::App for RanimPreviewApp {
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     let dark_mode = ui.visuals().dark_mode;
-                    let button_text = if dark_mode { "☀ Light" } else { "🌙 Dark" };
+                    let button_text = if dark_mode {
+                        format!("{} Light", egui_phosphor::regular::SUN)
+                    } else {
+                        format!("{} Dark", egui_phosphor::regular::MOON)
+                    };
                     if ui.button(button_text).clicked() {
                         if dark_mode {
                             ctx.set_visuals(egui::Visuals::light());
@@ -700,14 +692,14 @@ impl eframe::App for RanimPreviewApp {
                     let frame_dur = 1.0 / fps;
 
                     // |< Jump to start
-                    if ui.button("⏮").on_hover_text("Jump to start").clicked() {
+                    if ui.button(egui_phosphor::regular::SKIP_BACK).on_hover_text("Jump to start").clicked() {
                         self.timeline_state.current_sec = 0.0;
                         self.play_prev_t = None;
                     }
 
                     // < Step back one frame
                     if ui
-                        .button("⏪")
+                        .button(egui_phosphor::regular::CARET_LEFT)
                         .on_hover_text("Step back one frame")
                         .clicked()
                     {
@@ -718,7 +710,11 @@ impl eframe::App for RanimPreviewApp {
 
                     // Play / Pause
                     let is_playing = self.play_prev_t.is_some();
-                    let play_label = if is_playing { "⏸" } else { "▶" };
+                    let play_label = if is_playing {
+                        egui_phosphor::regular::PAUSE
+                    } else {
+                        egui_phosphor::regular::PLAY
+                    };
                     let play_tooltip = if is_playing { "Pause" } else { "Play" };
                     if ui.button(play_label).on_hover_text(play_tooltip).clicked() {
                         if is_playing {
@@ -733,7 +729,7 @@ impl eframe::App for RanimPreviewApp {
 
                     // > Step forward one frame
                     if ui
-                        .button("⏩")
+                        .button(egui_phosphor::regular::CARET_RIGHT)
                         .on_hover_text("Step forward one frame")
                         .clicked()
                     {
@@ -744,7 +740,7 @@ impl eframe::App for RanimPreviewApp {
                     }
 
                     // >| Jump to end
-                    if ui.button("⏭").on_hover_text("Jump to end").clicked() {
+                    if ui.button(egui_phosphor::regular::SKIP_FORWARD).on_hover_text("Jump to end").clicked() {
                         self.timeline_state.current_sec = self.timeline_state.total_sec;
                         self.play_prev_t = None;
                     }
@@ -752,8 +748,7 @@ impl eframe::App for RanimPreviewApp {
                     ui.separator();
 
                     // Loop toggle
-                    let loop_label = if self.looping { "🔁" } else { "🔁" };
-                    let mut loop_btn = egui::Button::new(loop_label);
+                    let mut loop_btn = egui::Button::new(egui_phosphor::regular::ARROWS_CLOCKWISE);
                     if self.looping {
                         loop_btn = loop_btn.fill(ui.visuals().selection.bg_fill);
                     }
@@ -841,9 +836,6 @@ impl eframe::App for RanimPreviewApp {
                         self.export_total_frames = total;
                     }
                     ExportProgress::Done => {
-                        done = true;
-                    }
-                    ExportProgress::Cancelled => {
                         done = true;
                     }
                     ExportProgress::Error(err) => {
@@ -981,10 +973,6 @@ impl eframe::App for RanimPreviewApp {
                                 ui.label("Preparing...");
                             });
                         }
-                        if ui.button("Cancel").clicked() {
-                            self.export_cancel
-                                .store(true, std::sync::atomic::Ordering::Relaxed);
-                        }
                     } else if ui.button("Start Export").clicked() {
                         self.start_export(ctx.clone());
                     }
@@ -1014,8 +1002,10 @@ pub fn run_app(app: RanimPreviewApp, #[cfg(target_arch = "wasm32")] container_id
         eframe::run_native(
             &title,
             native_options,
-            Box::new(|_cc| {
-                // If we wanted to access wgpu context on creation, we could do it here from _cc.wgpu_render_state
+            Box::new(|cc| {
+                let mut fonts = egui::FontDefinitions::default();
+                egui_phosphor::add_to_fonts(&mut fonts, egui_phosphor::Variant::Regular);
+                cc.egui_ctx.set_fonts(fonts);
                 Ok(Box::new(app))
             }),
         )

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -10,8 +10,8 @@ use ranim_core::store::CoreItemStore;
 use ranim_core::{SealedRanimScene, TimeMark};
 use ranim_render::resource::{RenderPool, RenderTextures};
 use ranim_render::{Renderer, utils::WgpuContext};
-use std::time::Duration;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use std::time::Instant;
 use tracing::{Span, info, instrument, trace};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
@@ -74,7 +74,7 @@ pub fn render_scene_output_with_progress(
     trace!("Build timeline cost: {:?}", t.elapsed());
 
     let mut app = RanimRenderApp::new(name, scene_config, output, buffer_count);
-    app.render_timeline(&scene, on_progress);
+    app.render_scene_with_progress(&scene, on_progress);
     if !scene.time_marks().is_empty() {
         app.render_capture_marks(&scene);
     }
@@ -154,9 +154,7 @@ impl RenderWorker {
 
         let mut output_dir = PathBuf::from(&output.dir);
         if !output_dir.is_absolute() {
-            output_dir = std::env::current_dir()
-                .unwrap()
-                .join(output_dir);
+            output_dir = std::env::current_dir().unwrap().join(output_dir);
         }
         let renderer = Renderer::new(&ctx, output.width, output.height, 8);
         let render_textures: Vec<RenderTextures> = (0..buffer_count)
@@ -372,7 +370,7 @@ impl RanimRenderApp {
     }
 
     #[instrument(skip_all)]
-    fn render_timeline(
+    pub fn render_scene_with_progress(
         &mut self,
         timeline: &SealedRanimScene,
         on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -10,11 +10,11 @@ use ranim_core::store::CoreItemStore;
 use ranim_core::{SealedRanimScene, TimeMark};
 use ranim_render::resource::{RenderPool, RenderTextures};
 use ranim_render::{Renderer, utils::WgpuContext};
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
-use std::{
-    path::{Path, PathBuf},
-    time::Instant,
-};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
 use tracing::{Span, info, instrument, trace};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
@@ -25,7 +25,6 @@ use ranim_render::PUFFIN_GPU_PROFILER;
 
 /// Render a scene with all its outputs
 pub fn render_scene(scene: &Scene, buffer_count: usize) {
-    let clear_color = scene_config_to_clear_color(&scene.config);
     for (i, output) in scene.outputs.iter().enumerate() {
         info!(
             "Rendering output {}/{} ({})",
@@ -33,13 +32,12 @@ pub fn render_scene(scene: &Scene, buffer_count: usize) {
             scene.outputs.len(),
             output.format
         );
-        render_scene_output_with_progress(
+        render_scene_output(
             scene.constructor,
             scene.name.to_string(),
-            clear_color,
+            &scene.config,
             output,
             buffer_count,
-            None,
         );
     }
 }
@@ -52,29 +50,22 @@ pub fn render_scene_output(
     output: &Output,
     buffer_count: usize,
 ) {
-    let clear_color = scene_config_to_clear_color(scene_config);
-    render_scene_output_with_progress(constructor, name, clear_color, output, buffer_count, None);
+    render_scene_output_with_progress(constructor, name, scene_config, output, buffer_count, None, None);
 }
 
-fn scene_config_to_clear_color(scene_config: &SceneConfig) -> wgpu::Color {
-    let bg = color::try_color(&scene_config.clear_color)
-        .unwrap_or(color::color("#333333ff"))
-        .convert::<LinearSrgb>();
-    let [r, g, b, a] = bg.components.map(|x| x as f64);
-    wgpu::Color { r, g, b, a }
-}
-
-/// Render a scene output with optional progress callback.
+/// Render a scene output with optional progress callback and cancellation.
 ///
-/// The callback receives `(current_frame, total_frames)` and returns `true` to continue
-/// or `false` to cancel. Returns `true` if the render was cancelled.
+/// - `on_progress` receives `(current_frame, total_frames)` each frame.
+/// - `cancel` can be set to `true` to stop the render early.
+/// - Returns `true` if the render was cancelled.
 pub fn render_scene_output_with_progress(
     constructor: impl SceneConstructor,
     name: String,
-    clear_color: wgpu::Color,
+    scene_config: &SceneConfig,
     output: &Output,
     buffer_count: usize,
-    on_progress: Option<Box<dyn Fn(u64, u64) -> bool + Send>>,
+    on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
+    cancel: Option<Arc<AtomicBool>>,
 ) -> bool {
     use std::time::Instant;
 
@@ -87,8 +78,8 @@ pub fn render_scene_output_with_progress(
     let scene = constructor.build_scene();
     trace!("Build timeline cost: {:?}", t.elapsed());
 
-    let mut app = RanimRenderApp::new(name, clear_color, output, buffer_count);
-    let cancelled = app.render_timeline(&scene, &on_progress);
+    let mut app = RanimRenderApp::new(name, scene_config, output, buffer_count);
+    let cancelled = app.render_timeline(&scene, on_progress, cancel);
     if !cancelled && !scene.time_marks().is_empty() {
         app.render_capture_marks(&scene);
     }
@@ -137,7 +128,7 @@ struct RenderWorker {
 impl RenderWorker {
     fn new(
         scene_name: String,
-        clear_color: wgpu::Color,
+        scene_config: &SceneConfig,
         output: &Output,
         buffer_count: usize,
     ) -> Self {
@@ -177,6 +168,11 @@ impl RenderWorker {
         let render_textures: Vec<RenderTextures> = (0..buffer_count)
             .map(|_| renderer.new_render_textures(&ctx))
             .collect();
+        let clear_color = color::try_color(&scene_config.clear_color)
+            .unwrap_or(color::color("#333333ff"))
+            .convert::<LinearSrgb>();
+        let [r, g, b, a] = clear_color.components.map(|x| x as f64);
+        let clear_color = wgpu::Color { r, g, b, a };
         let (_, _, ext) = output.format.encoding_params();
         Self {
             ctx,
@@ -369,11 +365,11 @@ struct RanimRenderApp {
 impl RanimRenderApp {
     fn new(
         scene_name: String,
-        clear_color: wgpu::Color,
+        scene_config: &SceneConfig,
         output: &Output,
         buffer_count: usize,
     ) -> Self {
-        let render_worker = RenderWorker::new(scene_name, clear_color, output, buffer_count);
+        let render_worker = RenderWorker::new(scene_name, scene_config, output, buffer_count);
         Self {
             render_worker: Some(render_worker),
             fps: output.fps,
@@ -385,7 +381,8 @@ impl RanimRenderApp {
     fn render_timeline(
         &mut self,
         timeline: &SealedRanimScene,
-        on_progress: &Option<Box<dyn Fn(u64, u64) -> bool + Send>>,
+        on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
+        cancel: Option<Arc<AtomicBool>>,
     ) -> bool {
         let start = Instant::now();
         #[cfg(feature = "profiling")]
@@ -441,12 +438,13 @@ impl RanimRenderApp {
             });
 
             span.pb_inc(1);
-            if let Some(cb) = on_progress {
-                if !cb(i as u64 + 1, num_frames) {
-                    info!("Export cancelled at frame {}/{}", i + 1, num_frames);
-                    cancelled = true;
-                    break;
-                }
+            if let Some(cb) = &on_progress {
+                cb(i as u64 + 1, num_frames);
+            }
+            if cancel.as_ref().is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed)) {
+                info!("Export cancelled at frame {}/{}", i + 1, num_frames);
+                cancelled = true;
+                break;
             }
             span.pb_set_message(
                 format!(

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -18,7 +18,7 @@ use std::{
 use tracing::{Span, info, instrument, trace};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
-mod file_writer;
+pub(crate) mod file_writer;
 
 #[cfg(feature = "profiling")]
 use ranim_render::PUFFIN_GPU_PROFILER;
@@ -65,6 +65,11 @@ pub fn render_scene_output_with_progress(
     on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
 ) {
     use std::time::Instant;
+
+    info!(
+        "Output: {}x{} {}fps {} dir={:?} save_frames={}",
+        output.width, output.height, output.fps, output.format, output.dir, output.save_frames
+    );
 
     let t = Instant::now();
     let scene = constructor.build_scene();
@@ -153,7 +158,6 @@ impl RenderWorker {
         if !output_dir.is_absolute() {
             output_dir = std::env::current_dir()
                 .unwrap()
-                .join("./output")
                 .join(output_dir);
         }
         let renderer = Renderer::new(&ctx, output.width, output.height, 8);
@@ -371,7 +375,11 @@ impl RanimRenderApp {
     }
 
     #[instrument(skip_all)]
-    fn render_timeline(&mut self, timeline: &SealedRanimScene, on_progress: &Option<Box<dyn Fn(u64, u64) + Send>>) {
+    fn render_timeline(
+        &mut self,
+        timeline: &SealedRanimScene,
+        on_progress: &Option<Box<dyn Fn(u64, u64) + Send>>,
+    ) {
         let start = Instant::now();
         #[cfg(feature = "profiling")]
         let (_cpu_server, _gpu_server) = {

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -50,6 +50,20 @@ pub fn render_scene_output(
     output: &Output,
     buffer_count: usize,
 ) {
+    render_scene_output_with_progress(constructor, name, scene_config, output, buffer_count, None);
+}
+
+/// Render a scene output with optional progress callback.
+///
+/// The callback receives `(current_frame, total_frames)`.
+pub fn render_scene_output_with_progress(
+    constructor: impl SceneConstructor,
+    name: String,
+    scene_config: &SceneConfig,
+    output: &Output,
+    buffer_count: usize,
+    on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
+) {
     use std::time::Instant;
 
     let t = Instant::now();
@@ -57,7 +71,7 @@ pub fn render_scene_output(
     trace!("Build timeline cost: {:?}", t.elapsed());
 
     let mut app = RanimRenderApp::new(name, scene_config, output, buffer_count);
-    app.render_timeline(&scene);
+    app.render_timeline(&scene, &on_progress);
     if !scene.time_marks().is_empty() {
         app.render_capture_marks(&scene);
     }
@@ -357,7 +371,7 @@ impl RanimRenderApp {
     }
 
     #[instrument(skip_all)]
-    fn render_timeline(&mut self, timeline: &SealedRanimScene) {
+    fn render_timeline(&mut self, timeline: &SealedRanimScene, on_progress: &Option<Box<dyn Fn(u64, u64) + Send>>) {
         let start = Instant::now();
         #[cfg(feature = "profiling")]
         let (_cpu_server, _gpu_server) = {
@@ -404,12 +418,16 @@ impl RanimRenderApp {
 
         (0..num_frames)
             .map(|f| (f as f64 / fps).min(total_secs))
-            .for_each(|sec| {
+            .enumerate()
+            .for_each(|(i, sec)| {
                 worker_thread.sync_and_submit(|store| {
                     store.update(timeline.eval_at_sec(sec));
                 });
 
                 span.pb_inc(1);
+                if let Some(cb) = on_progress {
+                    cb(i as u64 + 1, num_frames);
+                }
                 span.pb_set_message(
                     format!(
                         "rendering {:.1?}/{:.1?}",

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -25,6 +25,7 @@ use ranim_render::PUFFIN_GPU_PROFILER;
 
 /// Render a scene with all its outputs
 pub fn render_scene(scene: &Scene, buffer_count: usize) {
+    let clear_color = scene_config_to_clear_color(&scene.config);
     for (i, output) in scene.outputs.iter().enumerate() {
         info!(
             "Rendering output {}/{} ({})",
@@ -32,12 +33,13 @@ pub fn render_scene(scene: &Scene, buffer_count: usize) {
             scene.outputs.len(),
             output.format
         );
-        render_scene_output(
+        render_scene_output_with_progress(
             scene.constructor,
             scene.name.to_string(),
-            &scene.config,
+            clear_color,
             output,
             buffer_count,
+            None,
         );
     }
 }
@@ -50,20 +52,30 @@ pub fn render_scene_output(
     output: &Output,
     buffer_count: usize,
 ) {
-    render_scene_output_with_progress(constructor, name, scene_config, output, buffer_count, None);
+    let clear_color = scene_config_to_clear_color(scene_config);
+    render_scene_output_with_progress(constructor, name, clear_color, output, buffer_count, None);
+}
+
+fn scene_config_to_clear_color(scene_config: &SceneConfig) -> wgpu::Color {
+    let bg = color::try_color(&scene_config.clear_color)
+        .unwrap_or(color::color("#333333ff"))
+        .convert::<LinearSrgb>();
+    let [r, g, b, a] = bg.components.map(|x| x as f64);
+    wgpu::Color { r, g, b, a }
 }
 
 /// Render a scene output with optional progress callback.
 ///
-/// The callback receives `(current_frame, total_frames)`.
+/// The callback receives `(current_frame, total_frames)` and returns `true` to continue
+/// or `false` to cancel. Returns `true` if the render was cancelled.
 pub fn render_scene_output_with_progress(
     constructor: impl SceneConstructor,
     name: String,
-    scene_config: &SceneConfig,
+    clear_color: wgpu::Color,
     output: &Output,
     buffer_count: usize,
-    on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
-) {
+    on_progress: Option<Box<dyn Fn(u64, u64) -> bool + Send>>,
+) -> bool {
     use std::time::Instant;
 
     info!(
@@ -75,11 +87,12 @@ pub fn render_scene_output_with_progress(
     let scene = constructor.build_scene();
     trace!("Build timeline cost: {:?}", t.elapsed());
 
-    let mut app = RanimRenderApp::new(name, scene_config, output, buffer_count);
-    app.render_timeline(&scene, &on_progress);
-    if !scene.time_marks().is_empty() {
+    let mut app = RanimRenderApp::new(name, clear_color, output, buffer_count);
+    let cancelled = app.render_timeline(&scene, &on_progress);
+    if !cancelled && !scene.time_marks().is_empty() {
         app.render_capture_marks(&scene);
     }
+    cancelled
 }
 
 /// drop it will close the channel and the thread loop will be terminated
@@ -124,7 +137,7 @@ struct RenderWorker {
 impl RenderWorker {
     fn new(
         scene_name: String,
-        scene_config: &SceneConfig,
+        clear_color: wgpu::Color,
         output: &Output,
         buffer_count: usize,
     ) -> Self {
@@ -164,12 +177,6 @@ impl RenderWorker {
         let render_textures: Vec<RenderTextures> = (0..buffer_count)
             .map(|_| renderer.new_render_textures(&ctx))
             .collect();
-        let clear_color = color::try_color(&scene_config.clear_color)
-            .unwrap_or(color::color("#333333ff"))
-            .convert::<LinearSrgb>();
-        let [r, g, b, a] = clear_color.components.map(|x| x as f64);
-        let clear_color = wgpu::Color { r, g, b, a };
-
         let (_, _, ext) = output.format.encoding_params();
         Self {
             ctx,
@@ -362,11 +369,11 @@ struct RanimRenderApp {
 impl RanimRenderApp {
     fn new(
         scene_name: String,
-        scene_config: &SceneConfig,
+        clear_color: wgpu::Color,
         output: &Output,
         buffer_count: usize,
     ) -> Self {
-        let render_worker = RenderWorker::new(scene_name, scene_config, output, buffer_count);
+        let render_worker = RenderWorker::new(scene_name, clear_color, output, buffer_count);
         Self {
             render_worker: Some(render_worker),
             fps: output.fps,
@@ -378,8 +385,8 @@ impl RanimRenderApp {
     fn render_timeline(
         &mut self,
         timeline: &SealedRanimScene,
-        on_progress: &Option<Box<dyn Fn(u64, u64) + Send>>,
-    ) {
+        on_progress: &Option<Box<dyn Fn(u64, u64) -> bool + Send>>,
+    ) -> bool {
         let start = Instant::now();
         #[cfg(feature = "profiling")]
         let (_cpu_server, _gpu_server) = {
@@ -424,36 +431,46 @@ impl RanimRenderApp {
         span.pb_set_style(&style);
         span.pb_set_length(num_frames);
 
-        (0..num_frames)
+        let mut cancelled = false;
+        for (i, sec) in (0..num_frames)
             .map(|f| (f as f64 / fps).min(total_secs))
             .enumerate()
-            .for_each(|(i, sec)| {
-                worker_thread.sync_and_submit(|store| {
-                    store.update(timeline.eval_at_sec(sec));
-                });
-
-                span.pb_inc(1);
-                if let Some(cb) = on_progress {
-                    cb(i as u64 + 1, num_frames);
-                }
-                span.pb_set_message(
-                    format!(
-                        "rendering {:.1?}/{:.1?}",
-                        Duration::from_secs_f64(sec),
-                        Duration::from_secs_f64(total_secs)
-                    )
-                    .as_str(),
-                );
+        {
+            worker_thread.sync_and_submit(|store| {
+                store.update(timeline.eval_at_sec(sec));
             });
+
+            span.pb_inc(1);
+            if let Some(cb) = on_progress {
+                if !cb(i as u64 + 1, num_frames) {
+                    info!("Export cancelled at frame {}/{}", i + 1, num_frames);
+                    cancelled = true;
+                    break;
+                }
+            }
+            span.pb_set_message(
+                format!(
+                    "rendering {:.1?}/{:.1?}",
+                    Duration::from_secs_f64(sec),
+                    Duration::from_secs_f64(total_secs)
+                )
+                .as_str(),
+            );
+        }
         self.render_worker.replace(worker_thread.retrive());
 
-        info!(
-            "rendered {} frames({:?}) in {:?}",
-            num_frames,
-            Duration::from_secs_f64(timeline.total_secs()),
-            start.elapsed(),
-        );
+        if cancelled {
+            info!("Export cancelled");
+        } else {
+            info!(
+                "rendered {} frames({:?}) in {:?}",
+                num_frames,
+                Duration::from_secs_f64(timeline.total_secs()),
+                start.elapsed(),
+            );
+        }
         trace!("render timeline cost: {:?}", start.elapsed());
+        cancelled
     }
 
     #[instrument(skip_all)]

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -10,8 +10,6 @@ use ranim_core::store::CoreItemStore;
 use ranim_core::{SealedRanimScene, TimeMark};
 use ranim_render::resource::{RenderPool, RenderTextures};
 use ranim_render::{Renderer, utils::WgpuContext};
-use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -50,14 +48,12 @@ pub fn render_scene_output(
     output: &Output,
     buffer_count: usize,
 ) {
-    render_scene_output_with_progress(constructor, name, scene_config, output, buffer_count, None, None);
+    render_scene_output_with_progress(constructor, name, scene_config, output, buffer_count, None);
 }
 
-/// Render a scene output with optional progress callback and cancellation.
+/// Render a scene output with optional progress callback.
 ///
-/// - `on_progress` receives `(current_frame, total_frames)` each frame.
-/// - `cancel` can be set to `true` to stop the render early.
-/// - Returns `true` if the render was cancelled.
+/// The callback receives `(current_frame, total_frames)` each frame.
 pub fn render_scene_output_with_progress(
     constructor: impl SceneConstructor,
     name: String,
@@ -65,8 +61,7 @@ pub fn render_scene_output_with_progress(
     output: &Output,
     buffer_count: usize,
     on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
-    cancel: Option<Arc<AtomicBool>>,
-) -> bool {
+) {
     use std::time::Instant;
 
     info!(
@@ -79,11 +74,10 @@ pub fn render_scene_output_with_progress(
     trace!("Build timeline cost: {:?}", t.elapsed());
 
     let mut app = RanimRenderApp::new(name, scene_config, output, buffer_count);
-    let cancelled = app.render_timeline(&scene, on_progress, cancel);
-    if !cancelled && !scene.time_marks().is_empty() {
+    app.render_timeline(&scene, on_progress);
+    if !scene.time_marks().is_empty() {
         app.render_capture_marks(&scene);
     }
-    cancelled
 }
 
 /// drop it will close the channel and the thread loop will be terminated
@@ -382,8 +376,7 @@ impl RanimRenderApp {
         &mut self,
         timeline: &SealedRanimScene,
         on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
-        cancel: Option<Arc<AtomicBool>>,
-    ) -> bool {
+    ) {
         let start = Instant::now();
         #[cfg(feature = "profiling")]
         let (_cpu_server, _gpu_server) = {
@@ -428,47 +421,36 @@ impl RanimRenderApp {
         span.pb_set_style(&style);
         span.pb_set_length(num_frames);
 
-        let mut cancelled = false;
-        for (i, sec) in (0..num_frames)
+        (0..num_frames)
             .map(|f| (f as f64 / fps).min(total_secs))
             .enumerate()
-        {
-            worker_thread.sync_and_submit(|store| {
-                store.update(timeline.eval_at_sec(sec));
-            });
+            .for_each(|(i, sec)| {
+                worker_thread.sync_and_submit(|store| {
+                    store.update(timeline.eval_at_sec(sec));
+                });
 
-            span.pb_inc(1);
-            if let Some(cb) = &on_progress {
-                cb(i as u64 + 1, num_frames);
-            }
-            if cancel.as_ref().is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed)) {
-                info!("Export cancelled at frame {}/{}", i + 1, num_frames);
-                cancelled = true;
-                break;
-            }
-            span.pb_set_message(
-                format!(
-                    "rendering {:.1?}/{:.1?}",
-                    Duration::from_secs_f64(sec),
-                    Duration::from_secs_f64(total_secs)
-                )
-                .as_str(),
-            );
-        }
+                span.pb_inc(1);
+                if let Some(cb) = &on_progress {
+                    cb(i as u64 + 1, num_frames);
+                }
+                span.pb_set_message(
+                    format!(
+                        "rendering {:.1?}/{:.1?}",
+                        Duration::from_secs_f64(sec),
+                        Duration::from_secs_f64(total_secs)
+                    )
+                    .as_str(),
+                );
+            });
         self.render_worker.replace(worker_thread.retrive());
 
-        if cancelled {
-            info!("Export cancelled");
-        } else {
-            info!(
-                "rendered {} frames({:?}) in {:?}",
-                num_frames,
-                Duration::from_secs_f64(timeline.total_secs()),
-                start.elapsed(),
-            );
-        }
+        info!(
+            "rendered {} frames({:?}) in {:?}",
+            num_frames,
+            Duration::from_secs_f64(timeline.total_secs()),
+            start.elapsed(),
+        );
         trace!("render timeline cost: {:?}", start.elapsed());
-        cancelled
     }
 
     #[instrument(skip_all)]

--- a/src/link_magic.rs
+++ b/src/link_magic.rs
@@ -38,7 +38,7 @@ pub struct StaticOutput {
     pub save_frames: bool,
     /// The name of the video, uses scene's name by default.
     pub name: Option<&'static str>,
-    /// The directory to save the output
+    /// The directory to save the output.
     pub dir: &'static str,
     /// The output format
     pub format: OutputFormat,
@@ -52,7 +52,7 @@ impl StaticOutput {
         fps: 60,
         save_frames: false,
         name: None,
-        dir: "./",
+        dir: "./output",
         format: OutputFormat::Mp4,
     };
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -82,9 +82,9 @@ pub struct Output {
     ///
     /// e.g. the output of name `my_video` will be outputed as `my_video_<width>x<height>_<fps>.mp4`.
     pub name: Option<String>,
-    /// The directory to save the output
+    /// The directory to save the output.
     ///
-    /// Related to the `output` folder, Or absolute.
+    /// Can be relative (resolved from cwd) or absolute.
     pub dir: String,
     /// The output video format.
     pub format: OutputFormat,
@@ -98,7 +98,7 @@ impl Default for Output {
             fps: 60,
             save_frames: false,
             name: None,
-            dir: "./".to_string(),
+            dir: "./output".to_string(),
             format: OutputFormat::default(),
         }
     }


### PR DESCRIPTION
Closes: #157

- **feat**: Dynamic resolution selector with aspect ratio presets (16:9, 16:10, 4:3, 1:1, 21:9)
- **feat**: Playback controls — play/pause (Space), frame step (arrow keys), loop toggle, speed control
- **feat**: Export dialog with inline progress bar, path preview, and disabled controls during export
- **feat**: `render_scene_output_with_progress` API for progress callbacks
- **refactor**: Replace emoji icons with `egui-phosphor` library icons
- **refactor**: Simplify `Output.dir` — now a direct output directory (default `./output`)
- **refactor**: Gate export logic behind `cfg(not(wasm), render)` for wasm compatibility

### Breaking Changes

- **`Output.dir`**: No longer relative to a hardcoded `./output/` parent. The value is now used directly as the output directory. Default changed from `"./"` to `"./output"`.

  ```rust
  // Before: dir was joined under ./output/
  Output { dir: "bench".into(), .. }  // → ./output/bench/

  // After: dir is used directly
  Output { dir: "./output/bench".into(), .. }  // → ./output/bench/
  ```

- **`render_scene_output`**: Signature unchanged, but a new `render_scene_output_with_progress` variant is available with an `on_progress: Option<Box<dyn Fn(u64, u64) + Send>>` callback.

---

## Preview App Enhancements

### Resolution Selector

Dropdown with common resolution presets grouped by aspect ratio. Renderer is recreated on change with OIT layer count auto-adjusted for GPU buffer limits.

### Playback Controls

Full transport bar with egui-phosphor icons:

| Control | Action |
|---------|--------|
| ⏮ Skip Back | Jump to start |
| ◀ Caret Left | Step back one frame |
| ⏯ Play/Pause | Toggle playback (also Space) |
| ▶ Caret Right | Step forward one frame |
| ⏭ Skip Forward | Jump to end |
| 🔄 Loop | Toggle looping |
| Speed | Drag value 0.1x–10x |

### Export Dialog

Single window with inline progress — no separate progress window. Controls are disabled during export via `add_enabled_ui`. Resolved output path is previewed below the directory input.

### Conditional Compilation

Export logic (dialog, progress polling, `start_export`) is gated behind `#[cfg(all(not(target_family = "wasm"), feature = "render"))]`, matching the render module's own gate.

## Output.dir Simplification

`Output.dir` is now the direct output directory path. All examples and benches updated accordingly (`dir: "bench"` → `dir: "./output/bench"`).