### PR TITLE
devshell: provide GUI runtime libs for the preview app

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -147,10 +147,18 @@
           ]
           ++ lib.optionals pkgs.stdenv.isLinux [
             pkgs.vulkan-loader
+            pkgs.wayland
+            pkgs.libxkbcommon
+            pkgs.libX11
           ];
 
           shellHook = lib.optionalString pkgs.stdenv.isLinux ''
-            export LD_LIBRARY_PATH="${lib.makeLibraryPath [ pkgs.vulkan-loader ]}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            export LD_LIBRARY_PATH="${lib.makeLibraryPath [
+              pkgs.vulkan-loader
+              pkgs.wayland
+              pkgs.libxkbcommon
+              pkgs.libX11
+            ]}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
           '';
         };
       }


### PR DESCRIPTION
## Problem

`ranim preview` panics at `eframe::run_native` with `WaylandError(Connection(NoWaylandLib))` when run inside `nix develop`: eframe/winit dlopens `libwayland-client` at runtime, but the dev shell only exported `vulkan-loader` in `LD_LIBRARY_PATH` (the system profile also lacks the library).

## Change

Add `wayland` (libwayland), `libxkbcommon` and `libX11` to the Linux dev shell packages and to the `shellHook` `LD_LIBRARY_PATH` in `flake.nix`.

Verified with `nix flake check --no-build` and `nix eval .#devShells.x86_64-linux.default.shellHook` (the export now includes the wayland/xkbcommon store paths).