### PR TITLE
fix(ci): pin Binaryen >= 110 for wasm-opt in website workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -44,8 +44,18 @@ jobs:
         with:
           tool: just, zola@0.22, wasm-bindgen
 
+      # Binaryen must be >= 110. Older versions (e.g. Ubuntu 22.04's apt
+      # binaryen 105) mislabel the `__wbindgen_externrefs` export as the funcref
+      # table when running `wasm-opt` on wasm-bindgen output, so
+      # `__wbindgen_init_externref_table` fails with
+      # `WebAssembly.Table.grow(): failed to grow table by N` at module init.
+      # Pin a modern release instead of using apt.
       - name: Install wasm-opt
-        run: sudo apt-get update && sudo apt-get install -y binaryen
+        run: |
+          curl -sSL -o /tmp/binaryen.tar.gz \
+            "https://github.com/WebAssembly/binaryen/releases/download/version_129/binaryen-version_129-x86_64-linux.tar.gz"
+          tar -xzf /tmp/binaryen.tar.gz -C /tmp
+          echo "/tmp/binaryen-version_129/bin" >> "$GITHUB_PATH"
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Problem

The deployed website's wasm examples (e.g. `basic`) fail to initialize with:

```
Uncaught RangeError: WebAssembly.Table.grow(): failed to grow table by 4
    at __wbindgen_init_externref_table (basic.js)
    at __wbg_finalize_init (basic.js)
```

## Root cause

The xtask pipeline builds wasm examples as `cargo build --target wasm32-unknown-unknown` → `wasm-bindgen` → `wasm-opt -Oz`. GitHub Actions CI installed `binaryen` via apt on **ubuntu-22.04**, which ships **Binaryen 105**.

Binaryen ≤ 108 has a bug: when optimizing wasm-bindgen output, it mislabels the exported `__wbindgen_externrefs` table to point at the module's *funcref* table (`min = max = 20387`, already full) instead of the externref table (`min = 1024`, no max). At runtime the generated glue does `table.grow(4)` on that full funcref table → `RangeError: failed to grow table by 4` during `__wbindgen_start()`.

Verified by rebuilding `basic` from scratch and running `wasm-opt -Oz` with Binaryen 104–129: versions **≤ 108** corrupt the table export (exact `RangeError` reproduced in Node), versions **≥ 110** keep it correct. The bug is fixed upstream in Binaryen v110. Local builds were unaffected because the dev toolchain uses Binaryen 129 (nixpkgs).

## Fix

Replace the apt install with a pinned **Binaryen 129** download from GitHub releases (matches local dev toolchain), with a comment documenting the ≥ 110 requirement.

Re-deploying the site (CI run on `main`) rebuilds all wasm examples with the fixed Binaryen.