### PR TITLE
feat: add name_template to Output for configurable output basename

### DIFF
--- a/packages/ranim-macros/src/lib.rs
+++ b/packages/ranim-macros/src/lib.rs
@@ -65,6 +65,7 @@ struct OutputDef {
     fps: u32,
     save_frames: bool,
     name: Option<String>,
+    name_template: Option<String>,
     dir: String,
     format: Option<String>,
 }
@@ -104,11 +105,16 @@ pub fn scene(args: TokenStream, input: TokenStream) -> TokenStream {
         fps,
         save_frames,
         name,
+        name_template,
         dir,
         format,
     } in attrs.outputs
     {
         let name_token = match name.as_deref() {
+            Some(n) if !n.is_empty() => quote! { Some(#n) },
+            _ => quote! { None },
+        };
+        let name_template_token = match name_template.as_deref() {
             Some(n) if !n.is_empty() => quote! { Some(#n) },
             _ => quote! { None },
         };
@@ -126,6 +132,7 @@ pub fn scene(args: TokenStream, input: TokenStream) -> TokenStream {
                 fps: #fps,
                 save_frames: #save_frames,
                 name: #name_token,
+                name_template: #name_template_token,
                 dir: #dir,
                 format: #format_token,
             }
@@ -199,6 +206,7 @@ pub fn scene(args: TokenStream, input: TokenStream) -> TokenStream {
 /// - `fps`: frames per second
 /// - `save_frames`: save frames to disk
 /// - `dir`: directory for output
+/// - `name_template`: basename template for the output file
 #[proc_macro_attribute]
 pub fn output(_: TokenStream, _: TokenStream) -> TokenStream {
     TokenStream::new()

--- a/packages/ranim-macros/src/scene.rs
+++ b/packages/ranim-macros/src/scene.rs
@@ -60,6 +60,7 @@ pub fn parse_output_list(list: &MetaList) -> syn::Result<OutputDef> {
         fps: 60,
         save_frames: false,
         name: None,
+        name_template: None,
         dir: "./output".into(),
         format: None,
     };
@@ -79,6 +80,14 @@ pub fn parse_output_list(list: &MetaList) -> syn::Result<OutputDef> {
                 }) = nv.value
                 {
                     def.name = Some(s.value());
+                }
+            }
+            Some("name_template") => {
+                if let Expr::Lit(ExprLit {
+                    lit: Lit::Str(s), ..
+                }) = nv.value
+                {
+                    def.name_template = Some(s.value());
                 }
             }
             Some("dir") => {

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -20,6 +20,21 @@ pub(crate) mod file_writer;
 #[cfg(feature = "profiling")]
 use ranim_render::PUFFIN_GPU_PROFILER;
 
+/// Render the output basename template by replacing placeholders.
+///
+/// Supported placeholders:
+/// - `{name}`: the scene/output name
+/// - `{width}`: output width in pixels
+/// - `{height}`: output height in pixels
+/// - `{fps}`: output frame rate
+fn render_output_basename(template: &str, name: &str, width: u32, height: u32, fps: u32) -> String {
+    template
+        .replace("{name}", name)
+        .replace("{width}", &width.to_string())
+        .replace("{height}", &height.to_string())
+        .replace("{fps}", &fps.to_string())
+}
+
 /// Render a scene with all its outputs
 pub fn render_scene(scene: &Scene, buffer_count: usize) {
     for (i, output) in scene.outputs.iter().enumerate() {
@@ -196,13 +211,20 @@ impl RenderWorker {
                 FileWriterBuilder::default()
                     .with_fps(output.fps)
                     .with_size(output.width, output.height)
-                    .with_file_path(output_dir.join(format!(
-                        "{}_{}x{}_{}.{ext}",
-                        output.name.clone().unwrap_or(scene_name.clone()),
-                        output.width,
-                        output.height,
-                        output.fps
-                    )))
+                    .with_file_path(output_dir.join({
+                        let template = output
+                            .name_template
+                            .as_deref()
+                            .unwrap_or("{name}_{width}x{height}_{fps}");
+                        let base_name = render_output_basename(
+                            template,
+                            output.name.as_deref().unwrap_or(&scene_name),
+                            output.width,
+                            output.height,
+                            output.fps,
+                        );
+                        format!("{base_name}.{ext}")
+                    }))
                     .with_output_format(output.format),
             ),
             save_frames: output.save_frames,
@@ -579,4 +601,39 @@ pub fn download_ffmpeg(target_dir: impl AsRef<Path>) -> Result<PathBuf, anyhow::
     }
     info!("ffmpeg downloaded to {target_dir:?}");
     Ok(ffmpeg_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_output_basename;
+
+    #[test]
+    fn test_render_output_basename_default_template() {
+        assert_eq!(
+            render_output_basename("{name}_{width}x{height}_{fps}", "my_scene", 1920, 1080, 60),
+            "my_scene_1920x1080_60"
+        );
+    }
+
+    #[test]
+    fn test_render_output_basename_custom_template() {
+        assert_eq!(
+            render_output_basename(
+                "{name}_{fps}fps_{width}x{height}",
+                "my_scene",
+                1920,
+                1080,
+                60
+            ),
+            "my_scene_60fps_1920x1080"
+        );
+    }
+
+    #[test]
+    fn test_render_output_basename_name_only() {
+        assert_eq!(
+            render_output_basename("{name}", "my_scene", 1920, 1080, 60),
+            "my_scene"
+        );
+    }
 }

--- a/src/link_magic.rs
+++ b/src/link_magic.rs
@@ -38,6 +38,8 @@ pub struct StaticOutput {
     pub save_frames: bool,
     /// The name of the video, uses scene's name by default.
     pub name: Option<&'static str>,
+    /// The basename template for the rendered output.
+    pub name_template: Option<&'static str>,
     /// The directory to save the output.
     pub dir: &'static str,
     /// The output format
@@ -52,6 +54,7 @@ impl StaticOutput {
         fps: 60,
         save_frames: false,
         name: None,
+        name_template: None,
         dir: "./output",
         format: OutputFormat::Mp4,
     };
@@ -116,6 +119,7 @@ impl From<&StaticOutput> for Output {
             fps: o.fps,
             save_frames: o.save_frames,
             name: o.name.map(|n| n.to_string()),
+            name_template: o.name_template.map(|n| n.to_string()),
             dir: o.dir.to_string(),
             format: o.format,
         }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -84,6 +84,17 @@ pub struct Output {
     ///
     /// e.g. the output of name `my_video` will be outputed as `my_video_<width>x<height>_<fps>.mp4`.
     pub name: Option<String>,
+    /// The basename template for the rendered output.
+    ///
+    /// Supported placeholders:
+    /// - `{name}`: the scene/output name
+    /// - `{width}`: output width in pixels
+    /// - `{height}`: output height in pixels
+    /// - `{fps}`: output frame rate
+    ///
+    /// The file extension is appended automatically based on the output format.
+    /// Defaults to `{name}_{width}x{height}_{fps}`.
+    pub name_template: Option<String>,
     /// The directory to save the output.
     ///
     /// Can be relative (resolved from cwd) or absolute.
@@ -100,6 +111,7 @@ impl Default for Output {
             fps: 60,
             save_frames: false,
             name: None,
+            name_template: None,
             dir: "./output".to_string(),
             format: OutputFormat::default(),
         }


### PR DESCRIPTION
Closes #180

This PR adds a `name_template` field to `Output` / `StaticOutput` that lets users customize the rendered output basename, similar to export name templates in Premiere Pro or DaVinci Resolve.

## Changes

- Added `name_template: Option<String>` to `Output` (`src/scene.rs`) and `name_template: Option<&'static str>` to `StaticOutput` (`src/link_magic.rs`).
- Default template is `{name}_{width}x{height}_{fps}`, keeping the existing filename behavior unchanged when `name_template` is not set.
- Supported placeholders:
  - `{name}` — scene/output name
  - `{width}` — output width in pixels
  - `{height}` — output height in pixels
  - `{fps}` — output frame rate
- The file extension is appended automatically based on the output format.
- Updated the `#[output(...)]` macro to accept a `name_template = "..."` attribute.
- Added unit tests for the template rendering function.

## Example

```rust
#[scene]
#[output(name_template = "{name}_{width}x{height}_{fps}")]
fn my_scene(r: &mut RanimScene) {
    // ...
}
```

This will produce `my_scene_60fps_1920x1080.mp4` (extension depends on format).

---

## 中文说明

本 PR 为 `Output` / `StaticOutput` 添加了 `name_template` 字段，允许用户自定义渲染输出的文件 basename，类似于 Premiere Pro 或 DaVinci Resolve 的导出名模板。

- 默认模板为 `{name}_{width}x{height}_{fps}`，不设置时保持原有行为。
- 支持占位符：`{name}`、`{width}`、`{height}`、`{fps}`。
- 文件扩展名根据输出格式自动追加。
- `#[output(...)]` 宏新增 `name_template = "..."` 属性。
- 为模板渲染函数添加了单元测试。
