### PR TITLE
refactor(ranim-cli): split output and render commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For the usage, check out the [examples](./examples) folder. You can run the exam
 
 ```bash
 cargo run -p ranim-cli --release -- preview --example <example-name> # run a preview app for the example
-cargo run -p ranim-cli --release -- render --example <example-name> # render the example
+cargo run -p ranim-cli --release -- output --example <example-name> # render every declared output of the example
 ```
 
 See Ranim Cli for more.
@@ -89,14 +89,16 @@ fn main() {
 
 Basic Usage:
 - `ranim preview[ <scene_name>]`: Launch a preview app and invoke cargo to build your library automatically when the source code is changed, then reload it through *libloading* and show it in the preview app.
-- `ranim render[ <scene-name1> <scene_name2> ...]`: Render scene's output, when no scene name is specified, render all scenes.
+- `ranim output[ <scene-name1> <scene_name2> ...]`: Render every `#[output(...)]` declared by the selected scenes, including capture marks. When no scene name is specified, render all scenes.
+- `ranim render <scene_name>`: Render one scene once with default output settings (`1920x1080`, 60 fps, mp4). This is the low-level/ad-hoc render command, ignores `#[output(...)]`, and does not process capture marks.
 
 You can specify the package with `--package` and `--example` (just like cargo, note that your anim target should have crate-type of `dylib` or `cdylib`), and other aditional arguments you want to pass to `cargo build` can be passed after `--`.
 
 For example:
 
 ```bash
-ranim render -p render scene_a scene_b -- --release
+ranim output -p render scene_a scene_b -- --release
+ranim render -p render scene_a -- --release
 ```
 
 ## Feature Flags

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -188,7 +188,8 @@ cargo install ranim-cli
 
 ```bash
 ranim preview
-ranim render
+ranim output
+ranim output hello
 ranim render hello
 ```
 
@@ -196,12 +197,14 @@ ranim render hello
 
 ```bash
 ranim preview -p package_name --example example_name
-ranim render -p package_name --example example_name
+ranim output -p package_name --example example_name
+ranim render -p package_name --example example_name hello
 ```
 
-`preview` 可以接收一个可选 Scene 名称；`render` 可以接收零个或多个 Scene 名称。额外的 Cargo 构建参数放在 `--` 后，例如：
+`preview` 可以接收一个可选 Scene 名称；`output` 可以接收零个或多个 Scene 名称，并渲染它们声明的所有 `#[output(...)]`；`render` 接收恰好一个 Scene 名称，使用默认输出设置（`1920x1080`、60 fps、mp4）做一次临时渲染，不读取 `#[output(...)]`。额外的 Cargo 构建参数放在 `--` 后，例如：
 
 ```bash
+ranim output hello -- --release
 ranim render hello -- --release
 ```
 
@@ -209,5 +212,5 @@ ranim render hello -- --release
 
 ```bash
 cargo run -p ranim-cli --release -- preview --example getting_started0
-cargo run -p ranim-cli --release -- render --example getting_started0
+cargo run -p ranim-cli --release -- output --example getting_started0
 ```

--- a/packages/ranim-cli/src/cli.rs
+++ b/packages/ranim-cli/src/cli.rs
@@ -48,11 +48,17 @@ impl Cli {
             Commands::Preview { scene } => {
                 preview::preview_command(&args, &scene)?;
             }
-            Commands::Render {
+            Commands::Output {
                 scenes,
                 buffer_count,
             } => {
-                render::render_command(&args, &scenes, buffer_count)?;
+                render::output_command(&args, &scenes, buffer_count)?;
+            }
+            Commands::Render {
+                scene,
+                buffer_count,
+            } => {
+                render::render_command(&args, &scene, buffer_count)?;
             }
         }
 
@@ -64,11 +70,20 @@ impl Cli {
 pub enum Commands {
     /// Launch a preview app, watch the lib crate and rebuild it to dylib when it is changed
     Preview { scene: Option<String> },
-    /// Build the lib crate and load it, then render it to video
-    Render {
+    /// Render every `#[output(...)]` declared by the selected scenes
+    Output {
         /// Optional scene names to render (if not provided, render all scenes)
         #[arg(num_args = 0..)]
         scenes: Vec<String>,
+
+        /// Number of GPU readback buffers (higher = more parallelism, more VRAM)
+        #[arg(long, default_value_t = 2)]
+        buffer_count: usize,
+    },
+    /// Render a single scene once with default output settings (`1920x1080`, 60 fps, mp4)
+    Render {
+        /// Scene name to render
+        scene: String,
 
         /// Number of GPU readback buffers (higher = more parallelism, more VRAM)
         #[arg(long, default_value_t = 2)]
@@ -90,14 +105,20 @@ mod test {
             println!("result: {:?}", cli);
             cli
         };
-        let cli = parse_args(&["ranim", "render", "-p", "package"]).unwrap();
-        let Commands::Render { scenes, .. } = &cli.command else {
+        let cli = parse_args(&["ranim", "output", "-p", "package"]).unwrap();
+        let Commands::Output { scenes, .. } = &cli.command else {
             unreachable!()
         };
         assert!(scenes.is_empty());
         assert_eq!(cli.args.package, Some("package".to_string()));
         assert!(!cli.args.target.lib);
         assert!(cli.args.target.example.is_none());
+
+        let cli = parse_args(&["ranim", "render", "scene_name"]).unwrap();
+        let Commands::Render { scene, .. } = &cli.command else {
+            unreachable!()
+        };
+        assert_eq!(scene, "scene_name");
 
         let cli = parse_args(&["ranim", "preview", "--lib"]).unwrap();
         assert!(matches!(cli.command, Commands::Preview { scene: None }));

--- a/packages/ranim-cli/src/cli/render.rs
+++ b/packages/ranim-cli/src/cli/render.rs
@@ -1,5 +1,8 @@
 use anyhow::{Context, Result, bail};
-use ranim::{Scene, cmd::render_scene};
+use ranim::{
+    Output, Scene,
+    cmd::{render_scene, render_scene_once},
+};
 use tracing::{error, info};
 
 use crate::{
@@ -8,7 +11,7 @@ use crate::{
     workspace::{Workspace, get_target_package},
 };
 
-pub fn render_command(args: &CliArgs, scenes: &[String], buffer_count: usize) -> Result<()> {
+fn load_scenes(args: &CliArgs) -> Result<Vec<Scene>> {
     let workspace = Workspace::current()?;
 
     let (kid, package_name) = get_target_package(&workspace, args)?;
@@ -30,7 +33,12 @@ pub fn render_command(args: &CliArgs, scenes: &[String], buffer_count: usize) ->
         .recv_blocking()
         .context("Build worker exited without reporting")??;
 
-    let all_scenes: Vec<Scene> = lib.scenes().collect::<Vec<_>>();
+    Ok(lib.scenes().collect())
+}
+
+/// Render every `#[output(...)]` declared by the selected scenes.
+pub fn output_command(args: &CliArgs, scenes: &[String], buffer_count: usize) -> Result<()> {
+    let all_scenes = load_scenes(args)?;
     let scenes_to_render: Vec<&Scene> = if scenes.is_empty() {
         all_scenes.iter().collect()
     } else {
@@ -57,5 +65,36 @@ pub fn render_command(args: &CliArgs, scenes: &[String], buffer_count: usize) ->
         info!("Rendering scene: {}", scene.name);
         render_scene(scene, buffer_count);
     }
+    Ok(())
+}
+
+/// Render a single scene once with default output settings
+/// (`1920x1080`, 60 fps, mp4). Unlike [`output_command`], this command does
+/// not read any `#[output(...)]` declaration and does not process
+/// `TimeMark::Capture`.
+pub fn render_command(args: &CliArgs, scene_name: &str, buffer_count: usize) -> Result<()> {
+    let all_scenes = load_scenes(args)?;
+
+    let Some(scene) = all_scenes.iter().find(|scene| scene.name == scene_name) else {
+        error!("No matching scene found for: {scene_name:?}");
+        error!(
+            "Available scenes: {:?}",
+            all_scenes.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+        bail!("No scene to render");
+    };
+
+    let output = Output::default();
+    info!(
+        "Rendering scene {:?} once with default output: {}x{} {}fps {}",
+        scene.name, output.width, output.height, output.fps, output.format
+    );
+    render_scene_once(
+        scene.constructor,
+        scene.name.clone(),
+        &scene.config,
+        &output,
+        buffer_count,
+    );
     Ok(())
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,7 +2,10 @@
 #[cfg(all(not(target_family = "wasm"), feature = "render"))]
 pub mod render;
 #[cfg(all(not(target_family = "wasm"), feature = "render"))]
-pub use render::{render_scene, render_scene_output, render_scene_output_with_progress};
+pub use render::{
+    RenderJob, render_scene, render_scene_job, render_scene_once, render_scene_output,
+    render_scene_output_with_progress,
+};
 
 /// Render a scene by name.
 ///

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -65,7 +65,32 @@ pub fn render_scene_output(
     render_scene_output_with_progress(constructor, name, scene_config, output, buffer_count, None);
 }
 
-/// Render a scene output with optional progress callback.
+/// A single rendering job: one [`Output`] plus whether capture marks should
+/// be processed after the main pass.
+///
+/// The CLI currently only creates full-scene jobs. Time-range and still-frame
+/// rendering will extend this type together with the debug rendering commands.
+pub struct RenderJob {
+    /// Output settings used for this job.
+    pub output: Output,
+    /// Render and save every [`TimeMark::Capture`] after the main pass.
+    ///
+    /// This is enabled by `ranim output` (declared outputs) and disabled by
+    /// the ad-hoc `ranim render` command.
+    pub capture_marks: bool,
+}
+
+impl RenderJob {
+    /// Creates a job that renders the whole scene.
+    pub fn full(output: Output, capture_marks: bool) -> Self {
+        Self {
+            output,
+            capture_marks,
+        }
+    }
+}
+
+/// Render one output with optional progress callback.
 ///
 /// The callback receives `(current_frame, total_frames)` each frame.
 pub fn render_scene_output_with_progress(
@@ -76,7 +101,53 @@ pub fn render_scene_output_with_progress(
     buffer_count: usize,
     on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
 ) {
+    render_scene_job(
+        constructor,
+        name,
+        scene_config,
+        RenderJob::full(output.clone(), true),
+        buffer_count,
+        on_progress,
+    );
+}
+
+/// Render a single ad-hoc output for a scene.
+///
+/// This is the low-level rendering entry point used by `ranim render`: it
+/// renders the whole scene once with the given [`Output`], but unlike
+/// [`render_scene_output_with_progress`] it does not process capture marks.
+pub fn render_scene_once(
+    constructor: impl SceneConstructor,
+    name: String,
+    scene_config: &SceneConfig,
+    output: &Output,
+    buffer_count: usize,
+) {
+    render_scene_job(
+        constructor,
+        name,
+        scene_config,
+        RenderJob::full(output.clone(), false),
+        buffer_count,
+        None,
+    );
+}
+
+/// Build the scene and run a [`RenderJob`].
+pub fn render_scene_job(
+    constructor: impl SceneConstructor,
+    name: String,
+    scene_config: &SceneConfig,
+    job: RenderJob,
+    buffer_count: usize,
+    on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
+) {
     use std::time::Instant;
+
+    let RenderJob {
+        output,
+        capture_marks,
+    } = job;
 
     info!(
         "Output: {}x{} {}fps {} dir={:?} save_frames={}",
@@ -91,9 +162,10 @@ pub fn render_scene_output_with_progress(
     // decides which logic states are sampled.
     let mut evaluator = scene.into_evaluator(DEFAULT_LOGIC_FPS);
 
-    let mut app = RanimRenderApp::new(name, scene_config, output, buffer_count);
+    let mut app = RanimRenderApp::new(name, scene_config, &output, buffer_count);
     app.render_scene_with_progress(&mut evaluator, on_progress);
-    if !evaluator.time_marks().is_empty() {
+
+    if capture_marks && !evaluator.time_marks().is_empty() {
         app.render_capture_marks(&mut evaluator);
     }
 }


### PR DESCRIPTION
Related: #189

- **refactor**: split the old `ranim render` into `ranim output` (batch render of every declared `#[output]`) and `ranim render <scene>` (single-scene ad-hoc render)
- **feat**: add the `RenderJob` abstraction and `render_scene_once`, which renders without processing capture marks
- **docs**: update README and book CLI usage

### Breaking Changes

- **`ranim render`**: no longer renders every `#[output]` of the selected scenes. It now renders exactly one scene with default output settings (`1920x1080`, 60 fps, mp4), ignores `#[output]`, and does not process `TimeMark::Capture`. Migration: use `ranim output [scenes...]` for the previous behavior.

---

## ranim-cli command split

The old `render` command mixed two responsibilities: producing every declared output and ad-hoc debug rendering. Keeping both in one command would make future `--at` / `--range` / output overrides ambiguous, especially for scenes with multiple `#[output]` declarations.

This PR performs the first, pure split:

```text
ranim output [scenes...] [--buffer-count N]   # old render behavior: all #[output] + capture marks
ranim render <scene> [--buffer-count N]       # new low-level command: default output settings, one pass, no capture marks
```

`output` keeps the exact old `render` behavior. `render` is the future mount point for `[TIME]`, `--width/--height/--fps/--name-template`, etc. (see #189).

## RenderJob

Extracted a render job abstraction in `ranim::cmd::render`:

```rust
pub struct RenderJob {
    pub output: Output,
    pub capture_marks: bool,
}
```

- `render_scene_output_with_progress` keeps its signature and now delegates to a `RenderJob` with `capture_marks: true`, so the preview export path is unchanged.
- New `render_scene_once` uses `capture_marks: false` and backs `ranim render`.
- Time-range and still-frame modes will be added to `RenderJob` when the `[TIME]` argument is implemented.

## Verification

- `cargo check -p ranim-cli`
- `cargo test -p ranim-cli --lib`
- `cargo clippy -p ranim-cli --all-targets -- -D warnings`
- `cargo test -p ranim --features render --lib cmd::render::tests`

---

关联：#189

- **refactor**: 将原 `ranim render` 拆分为 `ranim output`（按 `#[output]` 声明批量渲染）和 `ranim render <scene>`（单场景临时渲染）
- **feat**: 新增 `RenderJob` 渲染任务抽象，以及不处理 capture marks 的 `render_scene_once` 入口
- **docs**: 更新 README 与 book 中的 CLI 用法

### Breaking Changes

- **`ranim render`**: 不再渲染选中场景的所有 `#[output]`；现在只渲染一个指定场景，使用默认输出设置（`1920x1080`、60 fps、mp4），忽略 `#[output]`，并且不处理 `TimeMark::Capture`。迁移路径：需要旧行为时改用 `ranim output [scenes...]`。

---

## ranim-cli 命令拆分

旧的 `render` 同时承担“按声明批量产出”和“调试期临时渲染”两种职责，后续 `--at` / `--range` / 输出覆盖在多 `#[output]` 场景下会产生歧义。

本 PR 只做第一步纯拆分：

```text
ranim output [scenes...] [--buffer-count N]   # 旧 render 行为：全部 #[output] + capture marks
ranim render <scene> [--buffer-count N]       # 新低级命令：默认输出设置，渲染一次，跳过 capture marks
```

`output` 保持旧 `render` 行为不变；`render` 作为后续 `[TIME]`、`--width/--height/--fps/--name-template` 等调试参数的挂载点（见 #189）。

## RenderJob

在 `ranim::cmd::render` 中抽出渲染任务抽象：

```rust
pub struct RenderJob {
    pub output: Output,
    pub capture_marks: bool,
}
```

- `render_scene_output_with_progress` 保留原签名，改为委托给 `capture_marks: true` 的 `RenderJob`，preview export 路径不受影响。
- 新增 `render_scene_once`：使用 `capture_marks: false`，作为 `ranim render` 的入口。
- 实现 `[TIME]` 参数时，再为 `RenderJob` 增加时段/单帧模式。

## 验证

- `cargo check -p ranim-cli`
- `cargo test -p ranim-cli --lib`
- `cargo clippy -p ranim-cli --all-targets -- -D warnings`
- `cargo test -p ranim --features render --lib cmd::render::tests`
