### PR TITLE
fix(ranim-cli): keep user dylib alive while rendering scenes

### DIFF
--- a/packages/ranim-cli/src/cli/render.rs
+++ b/packages/ranim-cli/src/cli/render.rs
@@ -6,12 +6,17 @@ use ranim::{
 use tracing::{error, info};
 
 use crate::{
-    RanimUserLibraryBuilder, Target,
+    RanimUserLibrary, RanimUserLibraryBuilder, Target,
     cli::CliArgs,
     workspace::{Workspace, get_target_package},
 };
 
-fn load_scenes(args: &CliArgs) -> Result<Vec<Scene>> {
+/// Build the user dylib, load it and collect its scenes.
+///
+/// The returned [`RanimUserLibrary`] must be kept alive for as long as the
+/// scenes are used: `Scene::constructor` is a function pointer into the
+/// dylib, so dropping the library unmaps the code it points to.
+fn load_scenes(args: &CliArgs) -> Result<(RanimUserLibrary, Vec<Scene>)> {
     let workspace = Workspace::current()?;
 
     let (kid, package_name) = get_target_package(&workspace, args)?;
@@ -33,12 +38,13 @@ fn load_scenes(args: &CliArgs) -> Result<Vec<Scene>> {
         .recv_blocking()
         .context("Build worker exited without reporting")??;
 
-    Ok(lib.scenes().collect())
+    let scenes = lib.scenes().collect();
+    Ok((lib, scenes))
 }
 
 /// Render every `#[output(...)]` declared by the selected scenes.
 pub fn output_command(args: &CliArgs, scenes: &[String], buffer_count: usize) -> Result<()> {
-    let all_scenes = load_scenes(args)?;
+    let (_lib, all_scenes) = load_scenes(args)?;
     let scenes_to_render: Vec<&Scene> = if scenes.is_empty() {
         all_scenes.iter().collect()
     } else {
@@ -73,7 +79,7 @@ pub fn output_command(args: &CliArgs, scenes: &[String], buffer_count: usize) ->
 /// not read any `#[output(...)]` declaration and does not process
 /// `TimeMark::Capture`.
 pub fn render_command(args: &CliArgs, scene_name: &str, buffer_count: usize) -> Result<()> {
-    let all_scenes = load_scenes(args)?;
+    let (_lib, all_scenes) = load_scenes(args)?;
 
     let Some(scene) = all_scenes.iter().find(|scene| scene.name == scene_name) else {
         error!("No matching scene found for: {scene_name:?}");


### PR DESCRIPTION
Related: #190

- **fix**: `ranim output` / `ranim render` crashed with SIGSEGV right after
  printing the output settings, before rendering any frame

---

## Root cause

#190 split the old `ranim render` into `output` / `render` and extracted the
scene-loading code into `load_scenes() -> Result<Vec<Scene>>`. Before the
split, `render_command` held the loaded dylib in a local for the whole
render; after the split, the `RanimUserLibrary` is dropped at the end of
`load_scenes`, which `dlclose`s the user dylib while every
`Scene::constructor` still points into it.

The next call into a constructor jumps into unmapped memory:

```text
munmap(0x72a7f06b4000, 471518) = 0            # dylib unmapped on drop
...
--- SIGSEGV {si_code=SEGV_MAPERR, si_addr=0x72a7f06e1e40} ---  # inside the unmapped PROT_EXEC segment
```

`ranim preview` is unaffected (it holds the library); only `output` and
`render` go through `load_scenes`.

## Fix

`load_scenes` now returns `(RanimUserLibrary, Vec<Scene>)`, and both
commands bind the library as `_lib` so it stays alive until rendering is
done, with a doc comment stating the lifetime requirement.

## Verification

- `cargo check -p ranim-cli`
- `cargo test -p ranim-cli --lib`
- `cargo clippy -p ranim-cli --all-targets -- -D warnings`
- `cargo run -p ranim-cli -- render nbody --example nbody` renders
  `nbody_1920x1080_60.mp4` (1920 frames); before the fix this segfaulted
  100% of the time.

---

关联：#190

- **fix**：`ranim output` / `ranim render` 在打印输出配置后立即 SIGSEGV，
  无法渲染任何帧

## 根因

#190 拆分 `output` / `render` 命令时把场景加载抽成了
`load_scenes() -> Result<Vec<Scene>>`。拆分前 `render_command` 在整个渲染
期间持有 dylib 句柄；拆分后 `RanimUserLibrary` 在 `load_scenes` 返回前被
drop（`dlclose`），而 `Scene::constructor` 仍是指向该 dylib 的函数指针，
下一次调用即跳入已解除映射的内存（strace 可见 dylib 被 munmap 后
SEGV_MAPERR 命中原 PROT_EXEC 段）。`preview` 命令因持有库句柄不受影响。

## 修复

`load_scenes` 返回 `(RanimUserLibrary, Vec<Scene>)`，两个命令以 `_lib`
持有库句柄至渲染结束，并以文档注释说明该存活要求。

## 验证

- `cargo check -p ranim-cli`
- `cargo test -p ranim-cli --lib`
- `cargo clippy -p ranim-cli --all-targets -- -D warnings`
- `cargo run -p ranim-cli -- render nbody --example nbody` 成功渲染
  `nbody_1920x1080_60.mp4`（1920 帧）；修复前必然崩溃。
