### PR TITLE
feat(wasm): experimental engine/plugin split with shared memory/table loader (experimental)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ output/
 
 .direnv/
 profile.json.gz
+# wasm engine/plugin demo build artifacts
+website/static/engine-plugin-demo/pkg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,15 @@ default = ["anims", "items"]
 anims = []
 items = []
 typst = ["ranim-items/typst"]
+# Wasm engine/plugin split experiment. Two orthogonal roles, mutually
+# exclusive; both are no-ops on non-wasm targets:
+# - `scene-engine`: host module — owns the shared memory/table and exports
+#   allocators/`register_scene`. Pair with `preview` for the interactive
+#   engine app, or with `render` for a headless one.
+# - `scene-plugin`: client module — imports the shared memory/table and
+#   forwards allocation to the engine.
+scene-engine = []
+scene-plugin = []
 profiling = [
   "ranim-render/profiling",
   "dep:puffin",
@@ -432,6 +441,15 @@ crate-type = ["cdylib"]
 
 [package.metadata.example.tetrahedron_spheres]
 wasm = true
+
+[[example]]
+name = "scenes_plugin"
+path = "examples/scenes_plugin.rs"
+crate-type = ["cdylib"]
+
+[package.metadata.example.scenes_plugin]
+hide = true
+wasm = false
 
 [[example]]
 name = "solar_system"

--- a/examples/scenes_plugin.rs
+++ b/examples/scenes_plugin.rs
@@ -1,0 +1,33 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+//! Scene plugin bundle for the wasm engine/plugin split demo.
+//!
+//! Built as a plain example of the root package with the `scene-plugin`
+//! feature, which activates the forwarding allocator and engine imports
+//! inside `ranim` itself (see `ranim::` `src/scene_plugin.rs`):
+//!
+//! ```bash
+//! RUSTFLAGS='<plugin link flags>' \
+//!     cargo build --example scenes_plugin --target wasm32-unknown-unknown \
+//!         --release --features scene-plugin
+//! ```
+//!
+//! The produced raw module imports the engine's memory/table/allocator and
+//! exports `scene_cnt()` / `get_scene(idx)` which the JS loader feeds back
+//! into the engine's `register_scene`.
+
+#[path = "aabb/lib.rs"]
+pub mod aabb;
+#[path = "arc/lib.rs"]
+pub mod arc;
+#[path = "arc_between_points/lib.rs"]
+pub mod arc_between_points;
+#[path = "bubble_sort/lib.rs"]
+pub mod bubble_sort;
+#[path = "ellipse/lib.rs"]
+pub mod ellipse;
+#[path = "hanoi/lib.rs"]
+pub mod hanoi;
+#[path = "regular_polygon/lib.rs"]
+pub mod regular_polygon;

--- a/justfile
+++ b/justfile
@@ -24,6 +24,9 @@ changelog:
 website:
     zola --root website build
 
+build-engine-demo:
+    cargo run -p xtask-examples -- build-engine-demo
+
 doc-nightly:
     RUSTDOCFLAGS="--cfg docsrs --html-in-header packages/ranim-examples/docs-rs/header.html" \
         cargo +nightly doc --workspace --no-deps --document-private-items --all-features \

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -1062,8 +1062,10 @@ pub fn run_app(app: RanimPreviewApp, #[cfg(target_arch = "wasm32")] container_id
             canvas.dyn_into::<web_sys::HtmlCanvasElement>().unwrap()
         };
 
-        wasm_bindgen_futures::spawn_local(async {
-            eframe::WebRunner::new()
+        wasm_bindgen_futures::spawn_local(async move {
+            let runner = eframe::WebRunner::new();
+            wasm::register_web_runner(runner.clone());
+            runner
                 .start(canvas, web_options, Box::new(build_app))
                 .await
                 .expect("failed to start eframe");
@@ -1105,6 +1107,16 @@ pub fn preview_scene_with_name(scene: &Scene, name: &str) {
 mod wasm {
     use super::*;
 
+    // Handle of the currently running web preview, so it can be destroyed
+    // before another one takes over the page (otherwise every previewed
+    // scene keeps its render loop alive).
+    //
+    // `WebRunner` is neither `Send` nor `Sync`, but wasm runs single-threaded.
+    thread_local! {
+        static WEB_RUNNER: std::cell::RefCell<Option<eframe::WebRunner>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
     #[wasm_bindgen(start)]
     pub async fn wasm_start() {
         console_error_panic_hook::set_once();
@@ -1115,5 +1127,22 @@ mod wasm {
     #[wasm_bindgen]
     pub fn preview_scene(scene: &Scene) {
         super::preview_scene(scene);
+    }
+
+    /// Destroy the currently running preview (if any), freeing its egui/wgpu
+    /// resources and stopping its repaint loop.
+    #[wasm_bindgen]
+    pub fn stop_preview() {
+        WEB_RUNNER.with_borrow_mut(|slot| {
+            if let Some(runner) = slot.take() {
+                runner.destroy();
+            }
+        });
+    }
+
+    pub(crate) fn register_web_runner(runner: eframe::WebRunner) {
+        // Destroy any previous runner before replacing it.
+        stop_preview();
+        WEB_RUNNER.with_borrow_mut(|slot| *slot = Some(runner));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,30 @@ pub mod utils {
 mod link_magic;
 pub use link_magic::*;
 
+// MARK: wasm engine/plugin split (experimental)
+
+// Two orthogonal build roles; both cfg gates include `target_family = "wasm"`
+// so neither affects native builds. The roles are mutually exclusive: a host
+// module owns the shared memory/table and serves scenes, a client module
+// imports them. Whether the host also carries the preview app is decided
+// independently via `preview`/`render`.
+#[cfg(all(
+    target_family = "wasm",
+    feature = "scene-engine",
+    feature = "scene-plugin"
+))]
+compile_error!(
+    "features `scene-engine` (host role) and `scene-plugin` (client role) are mutually exclusive"
+);
+
+/// Experimental wasm engine/plugin split exports (engine/host side).
+#[cfg(all(target_family = "wasm", feature = "scene-engine"))]
+mod wasm_engine;
+
+/// Client-side runtime for wasm scene plugins (`scene-plugin` feature).
+#[cfg(all(target_family = "wasm", feature = "scene-plugin"))]
+mod scene_plugin;
+
 /// Scene description types (Scene, Output, OutputFormat, etc.)
 mod scene;
 pub use scene::*;

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -148,3 +148,13 @@ impl SceneConstructor for Arc<dyn SceneConstructor> {
         self.as_ref().construct(r)
     }
 }
+
+#[cfg(all(target_arch = "wasm32", feature = "scene-engine"))]
+#[wasm_bindgen]
+impl Scene {
+    /// The scene name (JS getter).
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+}

--- a/src/scene_plugin.rs
+++ b/src/scene_plugin.rs
@@ -1,0 +1,63 @@
+//! Client-side runtime for wasm scene plugins (feature `scene-plugin`).
+//!
+//! A scene plugin is a wasm cdylib built against the shared engine module
+//! (`ranim` with the `preview` feature): it imports the engine's linear
+//! memory and funcref table, and forwards all heap allocation to the
+//! engine's exports, so `Vec`/`Box` values created by scene code can be
+//! owned and dropped by the engine exactly like with a native dylib.
+//!
+//! Plugin link flags (applied by the build toolchain):
+//! `--import-memory --import-table --no-stack-first
+//! --global-base=16777216 --table-base=65536`
+//!
+//! On non-wasm targets this module compiles to nothing: native dylibs share
+//! the host process allocator, so no forwarding is needed.
+
+use std::alloc::{GlobalAlloc, Layout};
+
+// SAFETY: these resolve to exports of the engine module provided by the JS
+// loader at instantiation time.
+#[link(wasm_import_module = "engine")]
+unsafe extern "C" {
+    fn engine_alloc(size: usize, align: usize) -> usize;
+    fn engine_alloc_zeroed(size: usize, align: usize) -> usize;
+    fn engine_dealloc(ptr: usize, size: usize, align: usize);
+    fn engine_realloc(ptr: usize, old_size: usize, new_size: usize, align: usize) -> usize;
+}
+
+/// Forwards every allocation to the engine module's exports.
+struct EngineAllocator;
+
+unsafe impl GlobalAlloc for EngineAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: caller guarantees a valid layout; engine side validates again.
+        unsafe { engine_alloc(layout.size(), layout.align()) as *mut u8 }
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: see `alloc`.
+        unsafe { engine_alloc_zeroed(layout.size(), layout.align()) as *mut u8 }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if ptr.is_null() {
+            return;
+        }
+        // SAFETY: ptr was allocated via the engine allocator with this layout.
+        unsafe { engine_dealloc(ptr as usize, layout.size(), layout.align()) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        if ptr.is_null() {
+            // SAFETY: valid layout by contract.
+            return unsafe {
+                self.alloc(Layout::from_size_align_unchecked(new_size, layout.align()))
+            };
+        }
+        // SAFETY: ptr was allocated via the engine allocator with this layout.
+        unsafe { engine_realloc(ptr as usize, layout.size(), new_size, layout.align()) as *mut u8 }
+    }
+}
+
+#[global_allocator]
+static GLOBAL_ALLOCATOR: EngineAllocator = EngineAllocator;

--- a/src/wasm_engine.rs
+++ b/src/wasm_engine.rs
@@ -1,0 +1,115 @@
+//! Experimental engine-side exports for the wasm engine/plugin split.
+//!
+//! The engine module (root `ranim` cdylib built with the `preview` feature)
+//! owns the shared `WebAssembly.Memory` and funcref table. Scene plugins are
+//! separate wasm modules built with `--import-memory --import-table` that
+//!
+//! - allocate through [`engine_alloc`] / [`engine_dealloc`] / [`engine_realloc`]
+//!   via a forwarding `#[global_allocator]`, so `Vec`/`Box` ownership works
+//!   across the module boundary exactly like a native dylib, and
+//! - export raw `scene_cnt()` / `get_scene(idx)` symbols (see
+//!   [`crate::link_magic`]) whose returned `*const StaticScene` pointers can be
+//!   handed to [`register_scene`] because both modules share one linear memory.
+//!
+//! Engine link flags: `--export-table --growable-table --no-stack-first
+//! --global-base=67108864 --initial-memory=83886080`.
+
+use wasm_bindgen::prelude::*;
+
+use std::alloc::GlobalAlloc;
+
+use crate::{Scene, link_magic::StaticScene};
+
+// MARK: allocator exports
+
+/// Allocate in the engine heap; called by scene plugins' forwarding allocator.
+///
+/// # Safety
+///
+/// `align` must be a power of two not exceeding 2^31.
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_alloc(size: usize, align: usize) -> usize {
+    layout_or_null(size, align, |layout| unsafe {
+        std::alloc::System.alloc(layout) as usize
+    })
+}
+
+/// Allocate zeroed memory in the engine heap.
+///
+/// # Safety
+///
+/// Same constraints as [`engine_alloc`].
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_alloc_zeroed(size: usize, align: usize) -> usize {
+    layout_or_null(size, align, |layout| unsafe {
+        std::alloc::System.alloc_zeroed(layout) as usize
+    })
+}
+
+/// Free an allocation made by [`engine_alloc`]/[`engine_realloc`].
+///
+/// # Safety
+///
+/// `ptr` must have been returned by [`engine_alloc`]/[`engine_realloc`] for an
+/// allocation of `size` bytes with alignment `align`.
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_dealloc(ptr: usize, size: usize, align: usize) {
+    if ptr == 0 {
+        return;
+    }
+    if let Ok(layout) = std::alloc::Layout::from_size_align(size, align) {
+        unsafe { std::alloc::System.dealloc(ptr as *mut u8, layout) };
+    }
+}
+
+/// Reallocate in the engine heap.
+///
+/// # Safety
+///
+/// `ptr` must have been allocated with (`old_size`, `align`) via the engine
+/// allocator.
+#[unsafe(no_mangle)]
+pub extern "C" fn engine_realloc(
+    ptr: usize,
+    old_size: usize,
+    new_size: usize,
+    align: usize,
+) -> usize {
+    if ptr == 0 {
+        return engine_alloc(new_size, align);
+    }
+    match std::alloc::Layout::from_size_align(old_size, align) {
+        Ok(old_layout) => unsafe {
+            std::alloc::System.realloc(ptr as *mut u8, old_layout, new_size) as usize
+        },
+        Err(_) => 0,
+    }
+}
+
+fn layout_or_null(size: usize, align: usize, f: impl FnOnce(std::alloc::Layout) -> usize) -> usize {
+    match std::alloc::Layout::from_size_align(size, align) {
+        Ok(layout) => f(layout),
+        Err(_) => 0,
+    }
+}
+
+// MARK: scene registration
+
+/// Register a scene from a plugin's `get_scene(idx)` pointer.
+///
+/// Returns `None` when `ptr` is null.
+///
+/// # Safety
+///
+/// `ptr` must point to a valid `StaticScene` inside the shared linear memory,
+/// produced by a loaded plugin module which must stay instantiated while the
+/// returned [`Scene`] (or previews built from it) is alive.
+#[wasm_bindgen]
+pub fn register_scene(ptr: u32) -> Option<Scene> {
+    if ptr == 0 {
+        return None;
+    }
+    // SAFETY: guaranteed by the JS loader contract, see module docs.
+    let s: &StaticScene = unsafe { &*(ptr as *const StaticScene) };
+    Some(Scene::from(s))
+}

--- a/website/static/engine-plugin-demo/index.html
+++ b/website/static/engine-plugin-demo/index.html
@@ -1,0 +1,349 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ranim · wasm engine/plugin split demo</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0 auto; max-width: 1080px; padding: 16px;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+    background: #16181d; color: #d7dae0;
+  }
+  h1 { font-size: 1.3rem; margin: 0 0 4px; }
+  .sub { color: #8a919c; font-size: 0.9rem; margin-bottom: 16px; }
+  a { color: #6cb6ff; }
+  section {
+    background: #1e2127; border: 1px solid #2d313a; border-radius: 8px;
+    padding: 12px 16px; margin-bottom: 14px;
+  }
+  h2 { font-size: 1rem; margin: 0 0 10px; color: #aab3bf; }
+  #status { font-family: ui-monospace, monospace; font-size: 0.85rem; white-space: pre-wrap; }
+  #status.ok { color: #7ec699; }
+  #status.err { color: #ff8888; }
+  #dropzone {
+    border: 2px dashed #3d4450; border-radius: 8px; padding: 28px;
+    text-align: center; cursor: pointer; transition: all .15s;
+  }
+  #dropzone.drag { border-color: #6cb6ff; background: #232a35; }
+  #plugin-info { font-size: 0.85rem; color: #8a919c; margin-top: 8px; font-family: ui-monospace, monospace; }
+  .scene-card {
+    display: flex; align-items: center; gap: 12px;
+    padding: 8px 12px; border-radius: 6px; margin-bottom: 6px; background: #262b33;
+  }
+  .scene-card button {
+    background: #2f6fdb; color: white; border: none; border-radius: 5px;
+    padding: 6px 14px; cursor: pointer; font-size: 0.85rem;
+  }
+  .scene-card button:hover { background: #3b7ee8; }
+  .scene-name { font-family: ui-monospace, monospace; font-size: 0.9rem; }
+  #stage { text-align: center; }
+  #stage canvas {
+    width: 100%; aspect-ratio: 16 / 9; height: auto;
+    background: #000; border-radius: 6px;
+  }
+  details { font-size: 0.85rem; color: #8a919c; }
+  summary { cursor: pointer; color: #aab3bf; }
+  code { background: #262b33; padding: 1px 5px; border-radius: 4px; font-size: 0.82em; }
+  pre { background: #14161a; border: 1px solid #2d313a; border-radius: 6px; padding: 10px; overflow-x: auto; font-size: 0.78rem; line-height: 1.5; }
+  .warn { color: #e0b56a; font-size: 0.82rem; margin-top: 6px; }
+</style>
+</head>
+<body>
+
+<h1>ranim · wasm 引擎/场景拆分实验</h1>
+<div class="sub">
+  一个引擎模块（<code>ranim</code> lib + preview，导出共享 memory/table/分配器）
+  + 按需加载的场景插件模块（<code>--import-memory --import-table</code>）。
+  参考 <em>wasm 场景 bundle 与引擎拆分调查</em> 方案 B。
+</div>
+
+<section>
+  <h2>引擎状态</h2>
+  <div id="status">正在初始化引擎…</div>
+</section>
+
+<section>
+  <h2>加载场景插件 (.wasm)</h2>
+  <div id="dropzone">
+    拖入插件 .wasm 文件，或点击选择<br>
+    <small style="color:#8a919c">内置示例插件由 <code>just build-engine-demo</code>（cargo examples build-engine-demo）产出</small>
+  </div>
+  <input id="file-input" type="file" accept=".wasm,application/wasm" hidden>
+  <div id="plugin-info"></div>
+</section>
+
+<section>
+  <h2>插件中的场景</h2>
+  <div id="scenes"><span style="color:#8a919c;font-size:.85rem">尚未加载插件</span></div>
+</section>
+
+<section>
+  <h2>预览（eframe/egui app 运行在引擎模块里）</h2>
+  <div id="stage"></div>
+</section>
+
+<section>
+  <details>
+    <summary>如何构建自己的场景插件？</summary>
+    <p>写一个只依赖 <code>ranim</code>（不带 <code>preview</code>）的 cdylib crate，
+       用 <code>#[path]</code> 或正常依赖引入若干 <code>#[scene]</code>，
+       并启用 <code>scene-plugin</code> feature——分配器转发与引擎导入声明都内置于
+       ranim，无需任何样板：</p>
+    <pre>ranim = { version = "…", default-features = false,
+         features = ["anims", "items", "scene-plugin"] }</pre>
+    <p>然后用以下 RUSTFLAGS 构建（与引擎共享 memory/table，静态区放在 16MiB 起）：</p>
+    <pre>RUSTFLAGS='--cfg getrandom_backend="wasm_js" \
+  -C link-arg=--import-memory \
+  -C link-arg=--import-table \
+  -C link-arg=--no-stack-first \
+  -C link-arg=--global-base=16777216 \
+  -C link-arg=--table-base=65536' \
+cargo build -p your-plugin --target wasm32-unknown-unknown --release</pre>
+    <p>约束：同一引擎实例同时只能挂一个同基址插件；插件 panic 会 trap 掉整个页面；
+       插件与引擎必须使用相同 rustc 版本、相同 ranim 版本编译。</p>
+  </details>
+</section>
+
+<script type="module">
+import initEngine, {
+  register_scene,
+  preview_scene,
+  stop_preview,
+  engine_memory,
+  engine_function_table,
+  raw_engine_alloc,
+  raw_engine_alloc_zeroed,
+  raw_engine_dealloc,
+  raw_engine_realloc,
+} from './pkg/ranim.js';
+
+const $status = document.getElementById('status');
+const $scenes = document.getElementById('scenes');
+const $stage = document.getElementById('stage');
+const $pluginInfo = document.getElementById('plugin-info');
+const $dropzone = document.getElementById('dropzone');
+const $fileInput = document.getElementById('file-input');
+
+const ENGINE_RAW_FNS = {
+  engine_alloc: raw_engine_alloc,
+  engine_alloc_zeroed: raw_engine_alloc_zeroed,
+  engine_dealloc: raw_engine_dealloc,
+  engine_realloc: raw_engine_realloc,
+};
+
+let loadedScenes = [];
+
+// 探测页面可用的 WebGPU 适配器：如果显示 SwiftShader/fallback，
+// 说明浏览器把 WebGPU 跑在 CPU 软渲染上——eval/render 计时只覆盖
+// wasm 侧工作，真正的光栅化都在 GPU（或软渲染）里，那才是卡的来源。
+async function probeGpuAdapter() {
+  try {
+    if (!navigator.gpu) return 'WebGPU API 不可用';
+    const adapter = await navigator.gpu.requestAdapter();
+    if (!adapter) return 'requestAdapter() 返回 null';
+    const info = adapter.info ?? (await adapter.requestAdapterInfo?.());
+    const bits = [
+      info?.vendor,
+      info?.architecture,
+      info?.device,
+      info?.description,
+    ].filter(Boolean);
+    if (adapter.isFallbackAdapter) bits.push('FALLBACK(软渲染)');
+    return bits.join(' ');
+  } catch (err) {
+    return `探测失败: ${err.message ?? err}`;
+  }
+}
+
+async function main() {
+  try {
+    await initEngine();
+    const mb = (engine_memory().buffer.byteLength / 1048576).toFixed(1);
+    const fnCount = engine_function_table().length;
+    const gpu = await probeGpuAdapter();
+    $status.textContent =
+      `引擎就绪  memory=${mb} MiB  table=${fnCount} entries\nWebGPU 适配器: ${gpu}`;
+    $status.className = 'ok';
+  } catch (err) {
+    $status.textContent = `引擎初始化失败: ${err}`;
+    $status.className = 'err';
+    console.error(err);
+  }
+}
+
+// Build the imports object for a raw plugin module by inspecting its actual
+// imports, wiring everything to the live engine instance.
+function buildPluginImports(wasmModule) {
+  const imports = Object.create(null);
+  const stubs = [];
+  for (const imp of WebAssembly.Module.imports(wasmModule)) {
+    let value;
+    switch (imp.kind) {
+      case 'memory':
+        value = engine_memory();
+        break;
+      case 'table':
+        value = engine_function_table();
+        break;
+      case 'function': {
+        if (imp.name.startsWith('engine_')) {
+          const fn = ENGINE_RAW_FNS[imp.name];
+          if (!fn) throw new Error(`插件引用了未知的引擎导出 ${imp.name}`);
+          value = fn;
+        } else {
+          // wasm-bindgen placeholder / getrandom 等未使用的导入：
+          // 保持可实例化，但一旦真的调用就直接抛错暴露问题。
+          stubs.push(`${imp.module}.${imp.name}`);
+          value = (...args) => {
+            throw new Error(
+              `插件调用了被 stub 的导入 ${imp.module}.${imp.name}(${args.length} args)` +
+              ' —— 该功能在拆分模式下不可用',
+            );
+          };
+        }
+        break;
+      }
+      default:
+        stubs.push(`${imp.module}.${imp.name} (${imp.kind})`);
+        value = undefined;
+    }
+    (imports[imp.module] ??= Object.create(null))[imp.name] = value;
+  }
+  return { imports, stubs };
+}
+
+// 共享表覆盖：引擎自身条目 + 插件区（base 65536 起）。预留到 128K 项，
+// 不够时 loadPlugin 会按需翻倍。
+const PLUGIN_TABLE_RESERVE = 131072;
+
+function ensureTableCapacity() {
+  const table = engine_function_table();
+  if (table.length < PLUGIN_TABLE_RESERVE) {
+    table.grow(PLUGIN_TABLE_RESERVE - table.length);
+  }
+}
+
+async function loadPlugin(bytes, label) {
+  const wasmModule = await WebAssembly.compile(bytes);
+  const { imports, stubs } = buildPluginImports(wasmModule);
+  // 插件以 --table-base=65536 落在共享表高位，其实例化声明的表最小值
+  // 通常远大于引擎当前的表长；表不会随元素段自动增长，需要先扩容。
+  ensureTableCapacity();
+  let instance;
+  try {
+    instance = await WebAssembly.instantiate(wasmModule, imports);
+  } catch (err) {
+    if (!/table import/i.test(String(err))) throw err;
+    // 按错误提示翻倍重试
+    const table = engine_function_table();
+    if (!table.grow(table.length)) throw err;
+    instance = await WebAssembly.instantiate(wasmModule, imports);
+  }
+  const exports = instance.exports;
+
+  if (typeof exports.scene_cnt !== 'function' || typeof exports.get_scene !== 'function') {
+    throw new Error('这不是场景插件模块（缺少 scene_cnt/get_scene 导出）');
+  }
+
+  // 同一引擎实例不能同时挂两个同基址插件：丢弃旧场景句柄。
+  loadedScenes.forEach((s) => s.handle = null);
+  loadedScenes = [];
+  $scenes.innerHTML = '';
+
+  const count = exports.scene_cnt();
+  for (let i = 0; i < count; i++) {
+    const ptr = exports.get_scene(i);
+    const handle = register_scene(ptr);
+    if (!handle) continue;
+    addSceneCard(handle, exports, label);
+  }
+
+  $pluginInfo.textContent =
+    `${label} · ${(bytes.byteLength / 1024).toFixed(0)} KiB · ${count} 个场景` +
+    (stubs.length ? ` · stub 导入: ${stubs.join(', ')}` : '');
+
+  if (loadedScenes.length === 0) {
+    $scenes.innerHTML = '<span style="color:#8a919c;font-size:.85rem">插件中没有注册任何 #[scene]</span>';
+  }
+}
+
+function addSceneCard(handle, pluginExports, label) {
+  const card = document.createElement('div');
+  card.className = 'scene-card';
+  const name = document.createElement('span');
+  name.className = 'scene-name';
+  name.textContent = handle.name;
+  const btn = document.createElement('button');
+  btn.textContent = 'Preview';
+  btn.onclick = () => preview(handle, label);
+  card.append(name, btn);
+  $scenes.appendChild(card);
+  loadedScenes.push({ name: handle.name, handle });
+}
+
+function preview(sceneHandle, label) {
+  // 先销毁上一个 app（释放 wgpu 资源、停掉重绘循环），再移除画布。
+  stop_preview();
+  $stage.innerHTML = '';
+  const canvas = document.createElement('canvas');
+  canvas.id = `ranim-app-${sceneHandle.name}`;
+  canvas.width = 1280;
+  canvas.height = 720;
+  $stage.appendChild(canvas);
+  console.info(`[demo] previewing "${sceneHandle.name}" from ${label}`);
+  preview_scene(sceneHandle);
+}
+
+$dropzone.onclick = () => $fileInput.click();
+$fileInput.onchange = async () => {
+  const file = $fileInput.files[0];
+  if (file) await safeLoad(file);
+  $fileInput.value = '';
+};
+['dragenter', 'dragover'].forEach((ev) =>
+  $dropzone.addEventListener(ev, (e) => { e.preventDefault(); $dropzone.classList.add('drag'); }));
+['dragleave', 'drop'].forEach((ev) =>
+  $dropzone.addEventListener(ev, (e) => { e.preventDefault(); $dropzone.classList.remove('drag'); }));
+$dropzone.addEventListener('drop', (e) => {
+  const file = e.dataTransfer?.files?.[0];
+  if (file) safeLoad(file);
+});
+
+async function safeLoad(file) {
+  try {
+    $pluginInfo.textContent = `加载中 ${file.name}…`;
+    const bytes = await file.arrayBuffer();
+    await loadPlugin(bytes, file.name);
+  } catch (err) {
+    console.error(err);
+    $pluginInfo.textContent = `加载失败: ${err.message ?? err}`;
+  }
+}
+
+// 支持 ?plugin=<url>&preview=<scene> 直接从 URL 加载插件并预览场景。
+async function loadFromQuery() {
+  const params = new URLSearchParams(location.search);
+  const pluginUrl = params.get('plugin');
+  if (!pluginUrl) return;
+  try {
+    $pluginInfo.textContent = `加载中 ${pluginUrl}…`;
+    const bytes = await (await fetch(pluginUrl)).arrayBuffer();
+    await loadPlugin(bytes, pluginUrl);
+    const wanted = params.get('preview');
+    if (wanted) {
+      const hit = loadedScenes.find((s) => s.name === wanted) ?? loadedScenes[0];
+      if (hit) preview(hit.handle, pluginUrl);
+    }
+  } catch (err) {
+    console.error(err);
+    $pluginInfo.textContent = `URL 插件加载失败: ${err.message ?? err}`;
+  }
+}
+
+main().then(loadFromQuery);
+</script>
+</body>
+</html>

--- a/xtasks/xtask-examples/src/engine_split_glue.js
+++ b/xtasks/xtask-examples/src/engine_split_glue.js
@@ -1,0 +1,6 @@
+export function engine_memory() { return wasm.memory; }
+export function engine_function_table() { return wasm.__indirect_function_table; }
+export function raw_engine_alloc(size, align) { return wasm.engine_alloc(size, align); }
+export function raw_engine_alloc_zeroed(size, align) { return wasm.engine_alloc_zeroed(size, align); }
+export function raw_engine_dealloc(ptr, size, align) { wasm.engine_dealloc(ptr, size, align); }
+export function raw_engine_realloc(ptr, old_size, new_size, align) { return wasm.engine_realloc(ptr, old_size, new_size, align); }

--- a/xtasks/xtask-examples/src/lib.rs
+++ b/xtasks/xtask-examples/src/lib.rs
@@ -131,6 +131,161 @@ fn clean_legacy_example_wasm_packages(root_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+// MARK: engine/plugin split demo
+
+/// Web directory of the experimental engine+plugin demo.
+const ENGINE_DEMO_WEB_DIR: &str = "engine-plugin-demo";
+/// Root-package example built as the wasm scene plugin (requires the
+/// `scene-plugin` feature). The example name doubles as the wasm crate/artifact
+/// name (`scenes_plugin.wasm`).
+const ENGINE_PLUGIN_EXAMPLE: &str = "scenes_plugin";
+/// Dedicated target dir: link flags differ per role and would otherwise
+/// thrash the default shared cache.
+const ENGINE_SPLIT_TARGET_DIR: &str = "target/engine-split";
+
+/// Link flags for the engine module: exports its memory/table and places
+/// static data high so the plugin region below stays untouched by heap growth.
+const ENGINE_RUSTFLAGS: &str = concat!(
+    r#"--cfg getrandom_backend="wasm_js" "#,
+    "-C link-arg=--export-table ",
+    "-C link-arg=--growable-table ",
+    "-C link-arg=--no-stack-first ",
+    "-C link-arg=--global-base=67108864 ",   // 64 MiB
+    "-C link-arg=--initial-memory=83886080", // 80 MiB
+);
+
+/// Link flags for a scene plugin: imports memory/table from the engine and
+/// places data/table entries low, far away from the engine's own region.
+const PLUGIN_RUSTFLAGS: &str = concat!(
+    r#"--cfg getrandom_backend="wasm_js" "#,
+    "-C link-arg=--import-memory ",
+    "-C link-arg=--import-table ",
+    "-C link-arg=--no-stack-first ",
+    "-C link-arg=--global-base=16777216 ", // 16 MiB
+    "-C link-arg=--table-base=65536",
+);
+
+fn cargo_wasm_build(root_dir: &Path, args: &[&str], rustflags: &str, step: &str) -> Result<()> {
+    let status = Command::new("cargo")
+        .current_dir(root_dir)
+        .args(["build", "--target", "wasm32-unknown-unknown", "--release"])
+        .args(args)
+        .args(["--target-dir", ENGINE_SPLIT_TARGET_DIR])
+        .env("RUSTFLAGS", rustflags)
+        .stdout(std::process::Stdio::null())
+        .status()
+        .context(format!("failed to run cargo build ({step})"))?;
+    if !status.success() {
+        bail!("cargo build failed ({step})");
+    }
+    Ok(())
+}
+
+/// Build the experimental wasm engine + scene plugin demo into
+/// `website/static/engine-plugin-demo/`.
+///
+/// Produces three artifacts:
+///
+/// 1. `pkg/ranim.js` + `pkg/ranim_bg.wasm`: the engine (`ranim` lib with
+///    `preview`), processed with `wasm-bindgen --keep-lld-exports` so raw lld
+///    exports (`memory`, table, allocator functions) stay reachable; the
+///    generated JS gains small wrappers exporting them.
+/// 2. `pkg/scenes_plugin.wasm`: a raw scene plugin module importing
+///    the engine's memory/table/allocator.
+pub fn build_engine_plugin_demo(root_dir: impl AsRef<Path>) -> Result<()> {
+    let root_dir = root_dir.as_ref();
+    let target_base = root_dir.join(ENGINE_SPLIT_TARGET_DIR);
+    let wasm_dir = target_base.join("wasm32-unknown-unknown").join("release");
+    let out_pkg = root_dir
+        .join("website")
+        .join("static")
+        .join(ENGINE_DEMO_WEB_DIR)
+        .join("pkg");
+    std::fs::create_dir_all(&out_pkg)?;
+
+    println!("[1/5] compiling engine (ranim + preview + scene-engine) for wasm32");
+    cargo_wasm_build(
+        root_dir,
+        &["-p", "ranim", "--features", "preview,scene-engine"],
+        ENGINE_RUSTFLAGS,
+        "engine",
+    )?;
+
+    println!("[2/5] compiling scene plugin (--example {ENGINE_PLUGIN_EXAMPLE} -F scene-plugin)");
+    cargo_wasm_build(
+        root_dir,
+        &[
+            "-p",
+            "ranim",
+            "--example",
+            ENGINE_PLUGIN_EXAMPLE,
+            "--features",
+            "scene-plugin",
+        ],
+        PLUGIN_RUSTFLAGS,
+        "plugin",
+    )?;
+
+    println!("[3/5] running wasm-bindgen on the engine (--keep-lld-exports)");
+    let engine_wasm = wasm_dir.join("ranim.wasm");
+    let status = Command::new("wasm-bindgen")
+        .current_dir(root_dir)
+        .args([
+            "--out-dir",
+            out_pkg.as_os_str().to_str().unwrap(),
+            "--target",
+            "web",
+            "--keep-lld-exports",
+            engine_wasm.as_os_str().to_str().unwrap(),
+        ])
+        .status()
+        .context("failed to run wasm-bindgen; is it installed?")?;
+    if !status.success() {
+        bail!("wasm-bindgen failed for the engine module");
+    }
+
+    println!("[4/5] appending raw export wrappers to ranim.js");
+    let engine_js_path = out_pkg.join("ranim.js");
+    let engine_js = fs::read_to_string(&engine_js_path)
+        .with_context(|| format!("failed to read {}", engine_js_path.display()))?;
+    if !engine_js.contains("// --- engine-split raw exports") {
+        let patched = format!(
+            "{engine_js}\n// --- engine-split raw exports (added by xtask) ---\n{}",
+            include_str!("engine_split_glue.js")
+        );
+        fs::write(&engine_js_path, patched)
+            .with_context(|| format!("failed to write {}", engine_js_path.display()))?;
+    }
+
+    println!("[5/5] optimizing wasm modules and copying plugin");
+    optimize_wasm(&out_pkg.join("ranim_bg.wasm")).context("failed to optimize the engine wasm")?;
+
+    let plugin_wasm_src = wasm_dir
+        .join("examples")
+        .join(format!("{ENGINE_PLUGIN_EXAMPLE}.wasm"));
+    let plugin_wasm_dst = out_pkg.join(format!("{ENGINE_PLUGIN_EXAMPLE}.wasm"));
+    let optimized_plugin = plugin_wasm_src.with_extension("opt.wasm");
+    let optimized = Command::new("wasm-opt")
+        .args(["-Oz", "--output"])
+        .arg(&optimized_plugin)
+        .arg(&plugin_wasm_src)
+        .stdout(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if optimized {
+        std::fs::copy(&optimized_plugin, &plugin_wasm_dst)?;
+        let _ = std::fs::remove_file(&optimized_plugin);
+    } else {
+        eprintln!(
+            "warning: wasm-opt unavailable/failed for the plugin, copying unoptimized module"
+        );
+        std::fs::copy(&plugin_wasm_src, &plugin_wasm_dst)?;
+    }
+
+    Ok(())
+}
+
 /// Optimize a wasm-bindgen output module for website delivery.
 ///
 /// `wasm-bindgen` may rewrite the module it receives, so this must run after
@@ -762,7 +917,7 @@ mod test {
         let xtask_root = Path::new(env!("CARGO_MANIFEST_DIR"));
         let root_dir = xtask_root.join("../../");
         let examples = get_examples(&root_dir).unwrap();
-        assert_eq!(examples.len(), 34); // + iterative_spring, nbody, cloth_wrap, agents
+        assert_eq!(examples.len(), 35); // + iterative_spring, nbody, cloth_wrap, agents, scenes_plugin
         assert_eq!(
             examples
                 .iter()

--- a/xtasks/xtask-examples/src/main.rs
+++ b/xtasks/xtask-examples/src/main.rs
@@ -8,7 +8,8 @@ use std::{
 
 use clap::{Parser, Subcommand};
 use xtask_examples::{
-    CleanStats, RunStatus, build_examples_wasm, clean_website_examples, get_examples,
+    CleanStats, RunStatus, build_engine_plugin_demo, build_examples_wasm, clean_website_examples,
+    get_examples,
 };
 
 #[derive(Parser)]
@@ -26,6 +27,8 @@ struct Args {
 enum Commands {
     /// Build the shared wasm bundle used by the website previews.
     Build,
+    /// Build the experimental wasm engine+plugin split demo.
+    BuildEngineDemo,
     /// Render examples and refresh website data/pages.
     Run {
         /// Skip examples whose rendered data is already up-to-date.
@@ -64,6 +67,10 @@ fn main() -> ExitCode {
 
     if matches!(&args.command, Commands::Build) {
         return build_examples_wasm_cmd(&workspace_root);
+    }
+
+    if matches!(&args.command, Commands::BuildEngineDemo) {
+        return build_engine_demo_cmd(&workspace_root);
     }
 
     let Commands::Run {
@@ -209,6 +216,20 @@ fn build_examples_wasm_cmd(workspace_root: &Path) -> ExitCode {
     }
     println!(
         "构建 wasm example bundle 完成 ({}s)",
+        format_duration(started.elapsed())
+    );
+    ExitCode::SUCCESS
+}
+
+fn build_engine_demo_cmd(workspace_root: &Path) -> ExitCode {
+    let started = Instant::now();
+    println!("构建 wasm engine+plugin demo…");
+    if let Err(err) = build_engine_plugin_demo(workspace_root) {
+        eprintln!("构建 wasm engine+plugin demo 失败: {err:#}");
+        return ExitCode::FAILURE;
+    }
+    println!(
+        "构建 wasm engine+plugin demo 完成 ({}s)",
         format_duration(started.elapsed())
     );
     ExitCode::SUCCESS


### PR DESCRIPTION
- **feat**: Two orthogonal wasm-only build roles in `ranim`: `scene-engine` (host) and `scene-plugin` (client), mutually exclusive, no-ops on non-wasm targets
- **feat**: Engine host exports (`engine_alloc/alloc_zeroed/dealloc/realloc`, `register_scene`) and client-side forwarding allocator for sound cross-module `Vec`/`Box` ownership
- **feat**: `stop_preview()` binding destroying the running eframe runner (prevents leaked render loops / wgpu resources when switching scenes)
- **feat**: `scenes_plugin` example bundle + `just build-engine-demo` xtask producing the bindgen'd engine module (with appended raw export wrappers) and a raw plugin artifact
- **feat**: Browser demo page under `website/static/engine-plugin-demo/` with drag-and-drop plugin loading, dynamic import wiring, table pre-growth, stub detection, and WebGPU adapter diagnostics

### Breaking Changes

- None. Default builds are untouched; both roles are opt-in features gated to `wasm32`.

---

## Background

Follow-up experiment for the *wasm scene bundle & engine split investigation* (方案 B). Phase 1 (#187) ships all examples as one self-contained 44MB bundle. This PR prototypes splitting it into:

1. one cached engine module (~10.3MB after `-Oz`) carrying the preview app,
2. tiny raw scene plugin modules (257KB here; ~35MB with typst) loaded at runtime.

## Role model

```toml
scene-engine = []   # host: owns shared memory/table, exports allocators + register_scene
scene-plugin = []   # client: imports memory/table, forwards allocation to the engine
preview      = [...] # UI axis, independent
```

- Both gates include `target_family = "wasm"` → native builds are completely unaffected.
- `scene-engine` × `scene-plugin` is enforced with a `compile_error!`.
- Legacy self-contained builds (`-F preview`) stay clean: verified that an example built with plain `preview` exports no split symbols.

## ABI & loader mechanics

```text
engine: -C link-arg=--export-table --growable-table --no-stack-first
        -C link-arg=--global-base=67108864 -C link-arg=--initial-memory=83886080
plugin: -C link-arg=--import-memory --import-table --no-stack-first
        -C link-arg=--global-base=16777216 -C link-arg=--table-base=65536
```

- Engine processed with `wasm-bindgen --keep-lld-exports`; small wrappers (`engine_memory`, `raw_engine_*`, …) are appended to the generated JS.
- Plugins ship as raw `.wasm` (no bindgen). The loader introspects `WebAssembly.Module.imports()` and wires memories/tables/engine functions dynamically; unused `__wbindgen_placeholder__` imports become loud stubs.
- The plugin's table import declares min ≈ 65k entries (`--table-base=65536`) while the fresh engine table has ~4.9k — tables don't auto-grow on import, so the loader pre-grows to 128K entries and doubles on `LinkError`.
- All plugin heap allocation is forwarded to the engine allocator, so evaluators built by plugin code can be owned and dropped by the engine.

## Demo

`just build-engine-demo && python3 -m http.server -d website/static` → `/engine-plugin-demo/`.

Drop any plugin `.wasm` onto the page: scenes are enumerated via `scene_cnt/get_scene`, registered through `register_scene`, and previewed in the embedded eframe app. `?plugin=<url>&preview=<scene>` deep-links work too. The status line reports the WebGPU adapter — during testing this exposed that Vivaldi ran WebGPU on software rasterization while Chrome used hardware (the reported eval/render times only cover wasm-side CPU work, which is why laggy software rendering still showed sub-millisecond timers).

## Verification

Headless Chromium e2e: engine init (80MiB memory, 4898 table entries), plugin instantiation against shared memory/table, all 9 bundled scenes registered, canvas attached by the eframe runner. `cargo fmt`, clippy (both roles, wasm target), xtask tests pass. Control experiment confirmed the existing single-bundle flow behaves identically in headless environments.

## Limitations & risks

- Plugin and engine must be built with the same rustc + ranim version and matching feature layout (same constraint as native dylibs).
- One plugin per engine instance: both use the same static-region base; loading another requires dropping the first (page reload for now).
- A panicking plugin traps the whole page (panic = abort).
- `--import-memory/--table-base/--keep-lld-exports` are rust-lld/wasm-bindgen internal flags; toolchain versions are pinned via the repo flake (bindgen 0.2.126, Binaryen 129).

---

- **feat**: `ranim` 新增两个正交的 wasm-only 构建角色：`scene-engine`（宿主）与 `scene-plugin`（客户端），互相排斥，非 wasm 目标下完全无副作用
- **feat**: 引擎宿主导出（`engine_alloc/alloc_zeroed/dealloc/realloc`、`register_scene`）与客户端转发分配器，保证跨模块 `Vec`/`Box` 所有权安全
- **feat**: 新增 `stop_preview()` 绑定销毁运行中的 eframe runner（避免切换场景时泄漏渲染循环 / wgpu 资源）
- **feat**: `scenes_plugin` 示例 bundle + `just build-engine-demo` xtask，产出 bindgen 处理过的引擎模块（追加 raw 导出包装）与裸插件产物
- **feat**: 浏览器 demo 页面（`website/static/engine-plugin-demo/`），支持拖拽加载插件、动态 import 接线、表扩容、stub 检测与 WebGPU 适配器诊断

### Breaking Changes

- 无。默认构建不受影响；两个角色均为 opt-in feature 且限定在 `wasm32`。

## 背景

*wasm 场景 bundle 与引擎拆分调查*（方案 B）的后续实验。Phase 1（#187）把所有例子打成单个自包含的 44MB bundle。本 PR 原型化将其拆分为：

1. 一个可缓存的引擎模块（`-Oz` 后约 10.3MB），携带 preview app；
2. 运行时加载的小体积裸场景插件模块（本文 257KB；带 typst 约 35MB）。

## 角色模型

```toml
scene-engine = []   # 宿主：拥有共享 memory/table，导出分配器 + register_scene
scene-plugin = []   # 客户端：导入 memory/table，把堆分配转发给引擎
preview      = [...] # UI 维度，独立决策
```

- 两个门控都包含 `target_family = "wasm"` → native 构建完全不受影响。
- `scene-engine` × `scene-plugin` 用 `compile_error!` 强制互斥。
- 老的自包含构建（`-F preview`）保持纯净：已验证纯 `preview` 构建的 example 不含任何拆分符号。

## ABI 与 loader 机制

```text
engine: -C link-arg=--export-table --growable-table --no-stack-first
        -C link-arg=--global-base=67108864 -C link-arg=--initial-memory=83886080
plugin: -C link-arg=--import-memory --import-table --no-stack-first
        -C link-arg=--global-base=16777216 -C link-arg=--table-base=65536
```

- 引擎经 `wasm-bindgen --keep-lld-exports` 处理；生成的 JS 末尾追加了小型包装（`engine_memory`、`raw_engine_*` 等）。
- 插件以裸 `.wasm` 分发（不经 bindgen）。loader 通过 `WebAssembly.Module.imports()` 自省并动态接线 memory/table/引擎函数；未使用的 `__wbindgen_placeholder__` 导入变成"一调用就报错"的 stub。
- 插件的表导入声明 min ≈ 65k 项（`--table-base=65536`），而新引擎表只有 ~4.9k——导入表不会随元素段自动增长，因此 loader 预扩容到 128K 项，遇到 `LinkError` 再翻倍重试。
- 插件的所有堆分配都转发到引擎分配器，插件代码构造的 evaluator 可由引擎安全持有和 drop。

## Demo

`just build-engine-demo && python3 -m http.server -d website/static` → `/engine-plugin-demo/`。

把任意插件 `.wasm` 拖入页面：通过 `scene_cnt/get_scene` 枚举场景，经 `register_scene` 注册，在内嵌 eframe app 中预览。也支持 `?plugin=<url>&preview=<scene>` 深链。状态栏会显示 WebGPU 适配器——测试期间正是它暴露了 Vivaldi 把 WebGPU 跑在软件光栅化上而 Chrome 使用硬件加速（页面上的 eval/render 计时只覆盖 wasm 侧 CPU 工作，所以软渲染很卡时计时仍然显示亚毫秒）。

## 验证

Headless Chromium 端到端：引擎初始化（80MiB memory、4898 表项）、插件基于共享 memory/table 实例化、9 个内置场景全部注册、eframe runner 成功挂载 canvas。`cargo fmt`、clippy（两种角色、wasm target）、xtask 测试全部通过。对照实验确认现有单 bundle 流程在 headless 环境下表现一致。

## 局限与风险

- 插件与引擎必须使用相同 rustc + ranim 版本及一致的 feature 布局（与 native dylib 相同约束）。
- 每个引擎实例同时只能挂一个插件：二者使用相同的静态区基址；换插件需先卸载旧的（当前为刷新页面）。
- 插件 panic 会 trap 整个页面（panic = abort）。
- `--import-memory/--table-base/--keep-lld-exports` 属于 rust-lld/wasm-bindgen 内部参数；工具链版本由仓库 flake 固定（bindgen 0.2.126、Binaryen 129）。
