### PR TITLE
feat(logic): M2 LogicWorld — retained ECS session + direct render extraction (experimental)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5156,6 +5156,7 @@ dependencies = [
  "anyhow",
  "assert_float_eq",
  "async-channel",
+ "bevy_ecs",
  "bytemuck",
  "console_error_panic_hook",
  "derive_more",
@@ -5245,6 +5246,7 @@ dependencies = [
 name = "ranim-examples"
 version = "0.2.1"
 dependencies = [
+ "bevy_ecs",
  "getrandom 0.4.3",
  "itertools 0.15.0",
  "midly",
@@ -5261,6 +5263,7 @@ name = "ranim-items"
 version = "0.2.1"
 dependencies = [
  "assert_float_eq",
+ "bevy_ecs",
  "chrono",
  "derive_more",
  "diff-match-patch-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ ranim-core.workspace = true
 ranim-items.workspace = true
 ranim-anims.workspace = true
 ranim-macros.workspace = true
+bevy_ecs.workspace = true
 itertools.workspace = true
 tracing.workspace = true
 derive_more = { workspace = true, features = [

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -23,6 +23,10 @@ name = "eval"
 harness = false
 
 [[bench]]
+name = "session"
+harness = false
+
+[[bench]]
 name = "render"
 harness = false
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -27,6 +27,10 @@ name = "session"
 harness = false
 
 [[bench]]
+name = "extract_path"
+harness = false
+
+[[bench]]
 name = "render"
 harness = false
 

--- a/benches/benches/extract_path.rs
+++ b/benches/benches/extract_path.rs
@@ -1,0 +1,80 @@
+//! CPU-side comparison of the two render-feeding paths:
+//! - buffered: SceneEvaluator -> EvaluatedFrame -> RenderFrame -> reconcile
+//! - direct:   ScenePlayer materialize -> world exchange -> reconcile_logic
+
+use std::hint::black_box;
+
+use benches::test_scenes::{static_squares, transform_squares};
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, SamplingMode, criterion_group, criterion_main,
+    measurement::WallTime,
+};
+use ranim::{SceneConstructor, bevy_ecs::world::World, prelude::*};
+use ranim_core::{EvaluatedFrame, SceneEvaluator, ScenePlayer, SealedRanimScene};
+use ranim_render::world::{RenderFrame, reconcile, reconcile_logic};
+
+const FRAMES: usize = 60;
+
+fn run_buffered(scene: SealedRanimScene) {
+    let mut session = SceneEvaluator::new(scene);
+    let total = session.total_secs();
+    let mut render_world = World::new();
+    let mut store = RenderFrame::new();
+    let mut frame = EvaluatedFrame::new();
+    for i in 0..FRAMES {
+        frame.clear();
+        session.sample_at(black_box(total * i as f64 / FRAMES as f64), &mut frame);
+        store.update(frame.drain(..));
+        reconcile(black_box(&mut render_world), black_box(&store));
+    }
+}
+
+fn run_direct(scene: SealedRanimScene) {
+    let mut player = ScenePlayer::new(scene);
+    let total = player.total_secs();
+    let mut render_world = World::new();
+    for i in 0..FRAMES {
+        player.materialize_at(black_box(total * i as f64 / FRAMES as f64));
+        let mut logic = player.take_world();
+        reconcile_logic(black_box(&mut render_world), black_box(&mut logic));
+        player.put_world(logic);
+    }
+}
+
+fn bench_pair(
+    group: &mut criterion::BenchmarkGroup<'_, WallTime>,
+    scene_name: &str,
+    n: usize,
+    build: impl Fn(&mut RanimScene, usize) + Copy + Send + Sync + 'static,
+) {
+    let id = |path: &str| BenchmarkId::new(format!("{scene_name}/{path}"), n);
+    group.bench_with_input(id("buffered"), &n, |b, n| {
+        b.iter_batched(
+            || (|r: &mut RanimScene| build(r, *n)).build_scene(),
+            run_buffered,
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_with_input(id("direct"), &n, |b, n| {
+        b.iter_batched(
+            || (|r: &mut RanimScene| build(r, *n)).build_scene(),
+            run_direct,
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn extract_path_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("extract_path");
+    group.sampling_mode(SamplingMode::Linear).sample_size(10);
+
+    for n in [10, 50] {
+        bench_pair(&mut group, "static_squares", n, static_squares);
+        bench_pair(&mut group, "transform_squares", n, transform_squares);
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, extract_path_benchmark);
+criterion_main!(benches);

--- a/benches/benches/session.rs
+++ b/benches/benches/session.rs
@@ -15,7 +15,7 @@ use ranim_core::{EvaluatedFrame, SceneEvaluator, ScenePlayer, SceneSession, Seal
 /// Sample `frames` evenly spaced points across the scene, reusing one frame
 /// buffer like the render loop does.
 fn sample_loop<S: SceneSession>(scene: SealedRanimScene, frames: usize) {
-    let mut session = S::from_sealed(scene, 120.0);
+    let mut session = S::from_sealed(scene);
     let total = session.total_secs();
     let mut frame = EvaluatedFrame::new();
     for i in 0..frames {

--- a/benches/benches/session.rs
+++ b/benches/benches/session.rs
@@ -1,0 +1,64 @@
+//! Frame-sampling comparison between the two `SceneSession` implementations:
+//! the pure evaluator (`SceneEvaluator`) and the retained-world player
+//! (`ScenePlayer`, M2 LogicWorld).
+
+use std::hint::black_box;
+
+use benches::test_scenes::{static_squares, transform_squares};
+use criterion::{
+    BatchSize, BenchmarkId, Criterion, SamplingMode, criterion_group, criterion_main,
+    measurement::WallTime,
+};
+use ranim::{SceneConstructor, prelude::*};
+use ranim_core::{EvaluatedFrame, SceneEvaluator, ScenePlayer, SceneSession, SealedRanimScene};
+
+/// Sample `frames` evenly spaced points across the scene, reusing one frame
+/// buffer like the render loop does.
+fn sample_loop<S: SceneSession>(scene: SealedRanimScene, frames: usize) {
+    let mut session = S::from_sealed(scene, 120.0);
+    let total = session.total_secs();
+    let mut frame = EvaluatedFrame::new();
+    for i in 0..frames {
+        frame.clear();
+        session.sample_at(black_box(total * i as f64 / frames as f64), &mut frame);
+        black_box(&frame);
+    }
+}
+
+fn bench_pair(
+    group: &mut criterion::BenchmarkGroup<'_, WallTime>,
+    scene_name: &str,
+    n: usize,
+    build: impl Fn(&mut RanimScene, usize) + Copy + Send + Sync + 'static,
+) {
+    let id = |session: &str| BenchmarkId::new(format!("{scene_name}/{session}"), n);
+    group.bench_with_input(id("evaluator"), &n, |b, n| {
+        b.iter_batched(
+            || (|r: &mut RanimScene| build(r, *n)).build_scene(),
+            |scene| sample_loop::<SceneEvaluator>(scene, 60),
+            BatchSize::SmallInput,
+        );
+    });
+    group.bench_with_input(id("player"), &n, |b, n| {
+        b.iter_batched(
+            || (|r: &mut RanimScene| build(r, *n)).build_scene(),
+            |scene| sample_loop::<ScenePlayer>(scene, 60),
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+fn session_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("session");
+    group.sampling_mode(SamplingMode::Linear).sample_size(10);
+
+    for n in [10, 50] {
+        bench_pair(&mut group, "static_squares", n, static_squares);
+        bench_pair(&mut group, "transform_squares", n, transform_squares);
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, session_benchmark);
+criterion_main!(benches);

--- a/benches/src/bin/profile_extract_path.rs
+++ b/benches/src/bin/profile_extract_path.rs
@@ -1,6 +1,6 @@
 //! samply profiling target: run one render-feeding path in a tight loop.
 //!
-//! Usage: profile_extract_path [buffered|direct] [n] [rounds]
+//! Usage: profile_extract_path [evaluator|player|buffered|direct] [n] [rounds]
 
 use std::hint::black_box;
 
@@ -11,8 +11,30 @@ use ranim_render::world::{RenderFrame, reconcile, reconcile_logic};
 
 const FRAMES: usize = 60;
 
-fn run_buffered(scene: SealedRanimScene, rounds: usize) {
+fn run_evaluator(scene: SealedRanimScene, rounds: usize) {
     let mut session = SceneEvaluator::new(scene);
+    let total = session.total_secs();
+    let mut frame = EvaluatedFrame::new();
+    for _ in 0..rounds {
+        for i in 0..FRAMES {
+            frame.clear();
+            session.sample_at(black_box(total * i as f64 / FRAMES as f64), &mut frame);
+            black_box(&frame);
+        }
+    }
+}
+
+fn run_player(scene: SealedRanimScene, rounds: usize) {
+    let mut player = ScenePlayer::new(scene);
+    let total = player.total_secs();
+    for _ in 0..rounds {
+        for i in 0..FRAMES {
+            player.materialize_at(black_box(total * i as f64 / FRAMES as f64));
+        }
+    }
+}
+
+fn run_buffered(scene: SealedRanimScene, rounds: usize) {    let mut session = SceneEvaluator::new(scene);
     let total = session.total_secs();
     let mut render_world = World::new();
     let mut store = RenderFrame::new();
@@ -49,6 +71,8 @@ fn main() {
 
     let scene = (|r: &mut RanimScene| transform_squares(r, n)).build_scene();
     match mode.as_str() {
+        "evaluator" => run_evaluator(scene, rounds),
+        "player" => run_player(scene, rounds),
         "buffered" => run_buffered(scene, rounds),
         "direct" => run_direct(scene, rounds),
         other => eprintln!("unknown mode: {other}"),

--- a/benches/src/bin/profile_extract_path.rs
+++ b/benches/src/bin/profile_extract_path.rs
@@ -1,0 +1,56 @@
+//! samply profiling target: run one render-feeding path in a tight loop.
+//!
+//! Usage: profile_extract_path [buffered|direct] [n] [rounds]
+
+use std::hint::black_box;
+
+use benches::test_scenes::transform_squares;
+use ranim::{SceneConstructor, bevy_ecs::world::World, prelude::*};
+use ranim_core::{EvaluatedFrame, SceneEvaluator, ScenePlayer, SealedRanimScene};
+use ranim_render::world::{RenderFrame, reconcile, reconcile_logic};
+
+const FRAMES: usize = 60;
+
+fn run_buffered(scene: SealedRanimScene, rounds: usize) {
+    let mut session = SceneEvaluator::new(scene);
+    let total = session.total_secs();
+    let mut render_world = World::new();
+    let mut store = RenderFrame::new();
+    let mut frame = EvaluatedFrame::new();
+    for _ in 0..rounds {
+        for i in 0..FRAMES {
+            frame.clear();
+            session.sample_at(black_box(total * i as f64 / FRAMES as f64), &mut frame);
+            store.update(frame.drain(..));
+            reconcile(black_box(&mut render_world), black_box(&store));
+        }
+    }
+}
+
+fn run_direct(scene: SealedRanimScene, rounds: usize) {
+    let mut player = ScenePlayer::new(scene);
+    let total = player.total_secs();
+    let mut render_world = World::new();
+    for _ in 0..rounds {
+        for i in 0..FRAMES {
+            player.materialize_at(black_box(total * i as f64 / FRAMES as f64));
+            let mut logic = player.take_world();
+            reconcile_logic(black_box(&mut render_world), black_box(&mut logic));
+            player.put_world(logic);
+        }
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mode = args.next().unwrap_or_else(|| "buffered".into());
+    let n: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(50);
+    let rounds: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(30);
+
+    let scene = (|r: &mut RanimScene| transform_squares(r, n)).build_scene();
+    match mode.as_str() {
+        "buffered" => run_buffered(scene, rounds),
+        "direct" => run_direct(scene, rounds),
+        other => eprintln!("unknown mode: {other}"),
+    }
+}

--- a/benches/src/bin/profile_session.rs
+++ b/benches/src/bin/profile_session.rs
@@ -1,0 +1,36 @@
+//! samply profiling target: run one scene session path in a tight loop.
+//!
+//! Usage: profile_session [evaluator|player] [n] [rounds]
+
+use std::hint::black_box;
+
+use benches::test_scenes::transform_squares;
+use ranim::{SceneConstructor, prelude::*};
+use ranim_core::{EvaluatedFrame, SceneEvaluator, ScenePlayer, SceneSession, SealedRanimScene};
+
+fn run<S: SceneSession>(scene: SealedRanimScene, frames: usize, rounds: usize) {
+    let mut session = S::from_sealed(scene);
+    let total = session.total_secs();
+    let mut frame = EvaluatedFrame::new();
+    for _ in 0..rounds {
+        for i in 0..frames {
+            frame.clear();
+            session.sample_at(black_box(total * i as f64 / frames as f64), &mut frame);
+            black_box(&frame);
+        }
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mode = args.next().unwrap_or_else(|| "evaluator".into());
+    let n: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(50);
+    let rounds: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(50);
+
+    let scene = (|r: &mut RanimScene| transform_squares(r, n)).build_scene();
+    match mode.as_str() {
+        "evaluator" => run::<SceneEvaluator>(scene, 60, rounds),
+        "player" => run::<ScenePlayer>(scene, 60, rounds),
+        other => eprintln!("unknown mode: {other}"),
+    }
+}

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -35,3 +35,4 @@
   - [v0.1]()
   - [v0.2]()
   - [v0.3](./designs/v0.3/README.md)
+  - [m2 LogicWorld](./designs/m2/README.md)

--- a/book/src/designs/m2/README.md
+++ b/book/src/designs/m2/README.md
@@ -1,0 +1,104 @@
+# M2 LogicWorld
+
+本文记录 M2 的设计：把 item 引入逻辑侧的 retained ECS World（`LogicWorld`），由
+`ScenePlayer` 驱动，输出与纯求值路径（`SceneEvaluator`）逐帧一致。核心问题只有一个：
+**动画表示是类型擦除的，而 ECS World 需要具体类型**——物化能力从何而来。
+
+## 两个擦除点
+
+动画表示里类型擦除发生在两个地方，而不是一个：
+
+```text
+E: Eval<Output = T>  ──Animation::build()──▶  Box<dyn EvalDyn>   （cell 层）
+        T            ──eval_dyn──▶           DynItem             （输出层）
+```
+
+类型擦除并没有丢失类型知识，而是把它搬进了 vtable——前提是所需的操作在擦除点被
+单态化为 vtable 条目。因此"擦除之后如何物化"的通用答案是：**物化必须是擦除点处
+捕获的钩子**。
+
+M2 最初（stage 1 初版）只在 cell 层补了一个 `EvalDyn::materialize_dyn`：每个节点在
+`eval_dyn` 之外再实现一条平行的类型化遍历，把 `Output` upsert 进 World。这个方案被
+否决了，它的失败解释了现在的设计：
+
+- 两条遍历必须永远路由一致（sequence 的逆序查找、stack/lagged 的全遍历、
+  `contains_sec` 的右端点特判各抄一遍），改一处漏一处就会让 World 与渲染静默
+  脱钩，编译器无法发现；
+- 输出层的擦除点补不上：`hold()` 与 lagged fill 在 build 期把 item 固化进静态
+  cell，此时类型已擦除为 `DynItem`，物化只能靠宿主 downcast 猜测核心类型，
+  自定义类型会被跳过并导致 part 计数错位。
+
+## DynItem 自物化钩子
+
+现在的设计把物化能力封进输出层的擦除点。`DynItem` 全仓只有一个构造点
+（blanket `eval_dyn`），因此它自带一个在构造时单态化的物化钩子：
+
+```rust,ignore
+pub struct DynItem {
+    inner: Box<dyn AnyExtractCoreItem>,
+    materialize: fn(Self, &mut MaterializeCtx, u32),  // downcast 回 T 并 upsert
+}
+```
+
+物化阶段不再需要自己的遍历，它就是共享的 eval 遍历加上每个 item 的自物化：
+
+```text
+materialize_at(sec) = cell.eval_at(sec) 得到 Vec<DynItem>
+                    → 每个 DynItem 用自带钩子 upsert 自身（按 part 槽位）
+```
+
+- 路由只有一份（`eval_dyn`），不存在两条遍历脱钩的可能；
+- 静态快照里的 `DynItem` 在捕获瞬间就带好了钩子，`hold`/lagged fill 中的自定义
+  类型也能正确物化；
+- `Vec<T>` 组输出作为一个 `DynItem`（经 `Batch<T>`）占一个槽位，与 extract 路径
+  的 1→N 展开语义一致。
+
+## 身份、生命周期与提取
+
+- **身份**：`(animation_id, part)`。`animation_id` 是顶层 cell 序号，`part` 是
+  cell 内输出槽位序号，与纯路径 `EvaluatedFrame` 的身份完全一致，因此渲染侧
+  `RenderWorld` reconciliation 不需要任何改动。
+- **生命周期 = 生产者生命周期**：`ScenePlayer.index` 持有跨帧的
+  `(animation_id, part) → Entity` 索引；同 key 再次物化只替换组件（entity 稳定
+  跨帧保留），本帧未出现的 key 对应 entity 被 despawn。
+- **槽位类型变化必须重建 entity**：sequence 切换子段后同一槽位的输出类型可能改变，
+  此时旧 entity 上的 `ItemExtractor` 与新组件类型不匹配。upsert 检测到槽位上不是
+  目标类型时必须 despawn 并重新 spawn，不得只 insert 新组件（旧组件会残留并被
+  旧 extractor 提取出陈旧值）。
+- **提取是类型擦除的 fn 指针**：entity spawn 时由物化点写入
+  `ItemExtractor(fn(Entity, &World, &mut Vec<CoreItem>))`，driver 不需要知道具体
+  类型即可把组件退化为 `CoreItem`；每帧提取结果写回 entity 的
+  `ExtractedItems(Vec<CoreItem>)`，buffer 跨帧复用。
+- **顺序与身份是两件事**：ECS 查询顺序不构成场景顺序，collect 阶段按
+  `SceneOrder` 显式排序，再把每个 entity 提取出的若干 `CoreItem` 扁平化为连续
+  part 序号。
+
+## ScenePlayer
+
+`ScenePlayer` 是 `SceneEvaluator` 的 retained-world 对照物。由于求值是纯查询
+（`eval_alpha`），它没有任何步进或 seek 簿记——方向管理内收于 `Iterative` 叶子，
+session 只暴露一帧的三段式管线：
+
+```text
+frame(render_secs) = materialize_at → extract → collect
+```
+
+测试保证其与 `SceneEvaluator::sample_at` 逐帧一致，且后跳采样与前向一致。
+
+## LogicItem 与 Batch：coherence 约束
+
+`LogicItem`（= `Component` + 可退化为 `CoreItem`）**不得有 blanket impl，必须逐个
+显式实现**。只有这样编译器才能证明 `Vec<T>` 不是 `LogicItem`，于是
+`MaterializeOut` 才能同时拥有两条互不冲突的路径：单 item（`T: LogicItem`）直接
+upsert；组输出（`Vec<T>`）包进 `Batch<T>` 组件作为单个 entity。给 `LogicItem`
+加 blanket impl 会导致两条 `MaterializeOut` impl 重叠，无法编译。
+
+## 边界
+
+- 渲染侧不在本设计范围内：collect 输出格式与纯路径相同即是全部契约。
+- 提取结果目前在 entity 上退化为 `CoreItem`（`ExtractedItems`）；让提取产物保持
+  类型化（`Extracted<T>`，供消费者按类型查询、并承接 `TextItem` 的派生缓存）是
+  本设计的既定延伸，不改变身份与生命周期模型。
+- 进程内 fn 指针假设 item 类型对宿主编译期可见；让类型可以来自宿主之外
+  （dylib/wasm 注册自己的物化器）需要一个同形状的全局 registry 替代 fn 指针，
+  同样不改变本设计的身份模型。

--- a/book/src/designs/m2/README.md
+++ b/book/src/designs/m2/README.md
@@ -73,7 +73,7 @@ materialize_at(sec) = cell.eval_at(sec) 得到 Vec<DynItem>
   `SceneOrder` 显式排序，再把每个 entity 提取出的若干 `CoreItem` 扁平化为连续
   part 序号。
 
-## ScenePlayer
+## ScenePlayer 与 SceneSession
 
 `ScenePlayer` 是 `SceneEvaluator` 的 retained-world 对照物。由于求值是纯查询
 （`eval_alpha`），它没有任何步进或 seek 簿记——方向管理内收于 `Iterative` 叶子，
@@ -82,6 +82,11 @@ session 只暴露一帧的三段式管线：
 ```text
 frame(render_secs) = materialize_at → extract → collect
 ```
+
+两者实现同一个 `SceneSession` trait（`from_sealed` / `total_secs` / `clock` /
+`time_marks` / `animation_infos` / `sample_at`），消费者对二者可互换：同一目标
+时刻的 `sample_at` 输出逐帧一致。`ScenePlayer::sample_at` 即 `frame`；
+`SceneEvaluator` 的同名方法原样委托。
 
 测试保证其与 `SceneEvaluator::sample_at` 逐帧一致，且后跳采样与前向一致。
 

--- a/book/src/designs/m2/README.md
+++ b/book/src/designs/m2/README.md
@@ -90,6 +90,34 @@ frame(render_secs) = materialize_at → extract → collect
 
 测试保证其与 `SceneEvaluator::sample_at` 逐帧一致，且后跳采样与前向一致。
 
+## 与纯路径的对照
+
+两条 session 共享 sealed scene 的顶层 cells、整棵类型擦除动画树（同一份
+`eval_at` 路由与同一份 `Iterative` 快照），差异从求值结果落地开始：
+
+```text
+共有:  cell.eval_at(sec) -> Vec<DynItem>          （同一棵树，同一个快照）
+
+纯路径 (SceneEvaluator::sample_at):
+  DynItem.extract() -> Vec<CoreItem>              （1→N 展开，move 进帧缓冲）
+  enumerate 得 part，直接 push
+
+World 路径 (ScenePlayer::frame):
+  materialize_at: DynItem 自物化 upsert 进 World   （HashMap 按身份 spawn/replace，
+                                                    帧末 despawn 消失的 key）
+  extract:        每 entity 经 ItemExtractor 读组件 -> ExtractedItems
+  collect:        按 SceneOrder 排序，逐 entity clone 展开进帧缓冲
+```
+
+- **数据驻留**：纯路径的帧是一次性产物；world 路径的 item 以 typed component
+  跨帧驻留，身份稳定——这是后续按类型查询与宿主外类型的地基，也是它存在的
+  全部理由。
+- **每帧拷贝**：纯路径 extract 时构造一次 `CoreItem` 并 move；world 路径
+  extract 生成一次、collect 再 clone 一次。叠加 entity/HashMap 簿记与排序，
+  这是 benchmark 中 world 路径每帧慢约 1.2–1.6 倍的来源，属于实现开销而非
+  结构差异（buffer swap、变更检测跳过未变 entity 都是既定优化方向）。
+- **确定性**：两者相同——帧一致与 seek 一致均由测试锁定。
+
 ## LogicItem 与 Batch：coherence 约束
 
 `LogicItem`（= `Component` + 可退化为 `CoreItem`）**不得有 blanket impl，必须逐个

--- a/book/src/designs/m2/README.md
+++ b/book/src/designs/m2/README.md
@@ -62,11 +62,12 @@ materialize_at(sec) = cell.eval_at(sec) 得到 Vec<DynItem>
   `(animation_id, part) → Entity` 索引；同 key 再次物化只替换组件（entity 稳定
   跨帧保留），本帧未出现的 key 对应 entity 被 despawn。
 - **槽位类型变化必须重建 entity**：sequence 切换子段后同一槽位的输出类型可能改变，
-  upsert 检测到槽位上不是目标类型时必须 despawn 并重新 spawn，不得只 insert
-  新组件（旧组件会残留，该槽位会被双重计算）。
-- **提取融合在物化里**：upsert 在仍持有 owned 值时顺手把它 extract 进 entity 的
-  `ExtractedItems(Vec<CoreItem>)`（`clear` + `extract_into`，分配跨帧复用）——
-  每个 item 每帧一次 clone，与纯路径同价，没有独立的 extract 遍历。
+  物化时检测到槽位上不是目标类型必须 despawn 并重新 spawn，不得只 insert
+  新组件（旧 typed 组件会残留并被该类型的消费者读到陈旧值）。该检测在钩子侧
+  执行（`TypeId` 只在认识 `T` 的一侧有效，见下文 dylib 规则）。
+- **提取融合在物化里**：钩子在仍持有 owned 值时顺手把它 extract 出来，经宿主侧
+  upsert 写入 entity 的 `ExtractedItems(Vec<CoreItem>)`——每个 item 每帧一次
+  clone，与纯路径同价，没有独立的 extract 遍历。
 - **顺序与身份是两件事**：ECS 查询顺序不构成场景顺序，collect 阶段按
   `SceneOrder` 显式排序，再把每个 entity 提取出的若干 `CoreItem` 扁平化为连续
   part 序号。
@@ -126,12 +127,40 @@ World 路径 (ScenePlayer::frame):
 upsert；组输出（`Vec<T>`）包进 `Batch<T>` 组件作为单个 entity。给 `LogicItem`
 加 blanket impl 会导致两条 `MaterializeOut` impl 重叠，无法编译。
 
+## 直接提取进渲染世界（world exchange）
+
+`EvaluatedFrame`/`RenderFrame` 帧缓冲是传输工件而非架构必需：离线渲染的完整路径
+可以不走缓冲——`ScenePlayer` 物化后把 `LogicWorld` 整体交给渲染线程
+（`take_world`/`put_world`，bevy 的 world exchange 同款），渲染侧
+`reconcile_logic` 按逻辑侧 `SceneOrder` 排序、drain 每个 entity 的
+`ExtractedItems`，以 move 语义直接 upsert 渲染组件（比较后替换，保留
+`Changed<T>`），然后照常跑 `RenderPrepare`/`RenderGraph`。帧缓冲路径（纯
+evaluator → `RenderFrame` → `reconcile`）不受任何影响，两条路共用渲染世界的
+身份与对账语义。离线渲染可用环境变量 `RANIM_SESSION=player` 切换到该路径。
+
+## dylib 规则：宿主可见面必须由宿主注册
+
+bevy 的组件注册以 `TypeId` 为键，而 `TypeId` 跨 dylib 边界不同。实测（dylib 构建
+的场景走直接提取路径）：在 dylib 内单态化的物化钩子若直接做 world 写入，注册出
+来的组件对宿主二进制完全不可见（world 有 2 个 entity，宿主查询命中 0 个），渲染
+侧直接 0 item。因此物化必须分侧：
+
+- **宿主侧**（`MaterializeCtx.upsert` fn 指针，由创建 ctx 的宿主代码注入）：
+  `ItemIdentity`/`SceneOrder`/`ExtractedItems` 的写入。钩子无论在哪一侧单态化，
+  都通过这个指针间接调用，宿主可见面对 dylib 场景同样成立——这是 stage 3
+  registry 的雏形。
+- **钩子侧**（钩子单态化所在的一侧）：owned 值的提取，以及 typed 组件 `T` 的
+  insert/`contains`——对 `T` 的 `TypeId` 敏感操作只在认识 `T` 的那一侧有效。
+  dylib 定义的 item 类型因此能进 world（宿主按身份/提取产物消费），但其 typed
+  组件宿主不可按类型查询，这正是 stage 3 registry 要解决的问题。
+
 ## 边界
 
-- 渲染侧不在本设计范围内：collect 输出格式与纯路径相同即是全部契约。
+- `EvaluatedFrame` 保留在三个位置：纯路径的输出契约、CLI inspect/调试接口、
+  player 与 evaluator 帧一致性测试的基准；热路径不再序列化经过它。
 - 提取结果目前在 entity 上退化为 `CoreItem`（`ExtractedItems`）；让提取产物保持
   类型化（`Extracted<T>`，供消费者按类型查询、并承接 `TextItem` 的派生缓存）是
   本设计的既定延伸，不改变身份与生命周期模型。
-- 进程内 `DynItem` 的物化钩子假设 item 类型对宿主编译期可见；让类型可以来自
-  宿主之外（dylib/wasm 注册自己的物化器）需要一个同形状的全局 registry 替代
-  钩子 fn 指针，同样不改变本设计的身份模型。
+- extract 阶段的去留：当前融合在物化里（等价于每帧全量的独立阶段）。若未来需要
+  并行 extract、变更检测跳过（与 drain 冲突，需要数据留在 world）或多消费者/帧率
+  解耦，extract 应以 schedule system 形态回归，物化侧无需改动。

--- a/book/src/designs/m2/README.md
+++ b/book/src/designs/m2/README.md
@@ -62,16 +62,18 @@ materialize_at(sec) = cell.eval_at(sec) 得到 Vec<DynItem>
   `(animation_id, part) → Entity` 索引；同 key 再次物化只替换组件（entity 稳定
   跨帧保留），本帧未出现的 key 对应 entity 被 despawn。
 - **槽位类型变化必须重建 entity**：sequence 切换子段后同一槽位的输出类型可能改变，
-  此时旧 entity 上的 `ItemExtractor` 与新组件类型不匹配。upsert 检测到槽位上不是
-  目标类型时必须 despawn 并重新 spawn，不得只 insert 新组件（旧组件会残留并被
-  旧 extractor 提取出陈旧值）。
-- **提取是类型擦除的 fn 指针**：entity spawn 时由物化点写入
-  `ItemExtractor(fn(Entity, &World, &mut Vec<CoreItem>))`，driver 不需要知道具体
-  类型即可把组件退化为 `CoreItem`；每帧提取结果写回 entity 的
-  `ExtractedItems(Vec<CoreItem>)`，buffer 跨帧复用。
+  upsert 检测到槽位上不是目标类型时必须 despawn 并重新 spawn，不得只 insert
+  新组件（旧组件会残留，该槽位会被双重计算）。
+- **提取融合在物化里**：upsert 在仍持有 owned 值时顺手把它 extract 进 entity 的
+  `ExtractedItems(Vec<CoreItem>)`（`clear` + `extract_into`，分配跨帧复用）——
+  每个 item 每帧一次 clone，与纯路径同价，没有独立的 extract 遍历。
 - **顺序与身份是两件事**：ECS 查询顺序不构成场景顺序，collect 阶段按
   `SceneOrder` 显式排序，再把每个 entity 提取出的若干 `CoreItem` 扁平化为连续
   part 序号。
+- **collect 是 drain 不是 clone**：collect 把 `ExtractedItems` 里的元素 move 进
+  帧缓冲（buffer 留在 world 复用容量）。推论：world 里的提取产物不跨帧保留，
+  未来若要做"值未变就跳过 extract"的变更检测，需要重新取舍——保留数据
+  （collect 回到 clone）或双层缓冲。
 
 ## ScenePlayer 与 SceneSession
 
@@ -80,7 +82,7 @@ materialize_at(sec) = cell.eval_at(sec) 得到 Vec<DynItem>
 session 只暴露一帧的三段式管线：
 
 ```text
-frame(render_secs) = materialize_at → extract → collect
+frame(render_secs) = materialize_at（upsert 融合 extract）→ collect（drain）
 ```
 
 两者实现同一个 `SceneSession` trait（`from_sealed` / `total_secs` / `clock` /
@@ -104,18 +106,16 @@ frame(render_secs) = materialize_at → extract → collect
 
 World 路径 (ScenePlayer::frame):
   materialize_at: DynItem 自物化 upsert 进 World   （HashMap 按身份 spawn/replace，
-                                                    帧末 despawn 消失的 key）
-  extract:        每 entity 经 ItemExtractor 读组件 -> ExtractedItems
-  collect:        按 SceneOrder 排序，逐 entity clone 展开进帧缓冲
+                 同时 extract 进 ExtractedItems；   帧末 despawn 消失的 key）
+  collect:        按 SceneOrder 排序，逐 entity drain（move）展开进帧缓冲
 ```
 
 - **数据驻留**：纯路径的帧是一次性产物；world 路径的 item 以 typed component
   跨帧驻留，身份稳定——这是后续按类型查询与宿主外类型的地基，也是它存在的
   全部理由。
-- **每帧拷贝**：纯路径 extract 时构造一次 `CoreItem` 并 move；world 路径
-  extract 生成一次、collect 再 clone 一次。叠加 entity/HashMap 簿记与排序，
-  这是 benchmark 中 world 路径每帧慢约 1.2–1.6 倍的来源，属于实现开销而非
-  结构差异（buffer swap、变更检测跳过未变 entity 都是既定优化方向）。
+- **每帧拷贝**：两条路径都只有一次 extract clone（物化时融合完成），world
+  路径多出的只是 entity/HashMap 簿记与排序，属于实现开销而非结构差异
+  （变更检测跳过未变 entity 是既定优化方向）。
 - **确定性**：两者相同——帧一致与 seek 一致均由测试锁定。
 
 ## LogicItem 与 Batch：coherence 约束
@@ -132,6 +132,6 @@ upsert；组输出（`Vec<T>`）包进 `Batch<T>` 组件作为单个 entity。�
 - 提取结果目前在 entity 上退化为 `CoreItem`（`ExtractedItems`）；让提取产物保持
   类型化（`Extracted<T>`，供消费者按类型查询、并承接 `TextItem` 的派生缓存）是
   本设计的既定延伸，不改变身份与生命周期模型。
-- 进程内 fn 指针假设 item 类型对宿主编译期可见；让类型可以来自宿主之外
-  （dylib/wasm 注册自己的物化器）需要一个同形状的全局 registry 替代 fn 指针，
-  同样不改变本设计的身份模型。
+- 进程内 `DynItem` 的物化钩子假设 item 类型对宿主编译期可见；让类型可以来自
+  宿主之外（dylib/wasm 注册自己的物化器）需要一个同形状的全局 registry 替代
+  钩子 fn 指针，同样不改变本设计的身份模型。

--- a/book/src/designs/v0.3/README.md
+++ b/book/src/designs/v0.3/README.md
@@ -391,7 +391,7 @@ impl SceneEvaluator {
 
 - `sample_at` 是唯一的 session 交互：渲染、preview 拖拽共用这条路径；
 - 前进 / 回退 / 原地求值由 `Iterative` 等 stateful 节点内部完成，session 不再维护逻辑网格；
-- `logic_fps` 参数仅为 API 兼容保留，不再驱动步进；步进尺度由每个迭代区段自己的 `sim_step` 决定。
+- 步进尺度由每个迭代区段自己的 `sim_step` 决定（早期的 `logic_fps` 参数已删除）。
 
 ### 模块布局
 

--- a/book/src/understand/core/anim.md
+++ b/book/src/understand/core/anim.md
@@ -465,5 +465,5 @@ trait object，因此 crate 为所有满足 `Output` 可提取为场景元素的
 - 前进 / 回退 / 原地求值的判断在 `Iterative` 等 stateful 节点内部完成；
 - preview 拖拽和 render 采样共用同一条路径。
 
-`logic_fps` 参数仅为 API 兼容保留，不再驱动步进；步进尺度由每个迭代区段自己
-的 `sim_step` 决定。
+步进尺度由每个迭代区段自己的 `sim_step` 决定，session 上没有全局时间分辨率
+参数（早期的 `logic_fps` 已删除）。

--- a/book/src/understand/core/core_item.md
+++ b/book/src/understand/core/core_item.md
@@ -49,7 +49,13 @@ pub trait Extract {
 
 ```rust,ignore
 pub trait AnyExtractCoreItem: Any + Extract<Target = CoreItem> + DynClone {}
-pub struct DynItem(pub Box<dyn AnyExtractCoreItem>);
+
+/// 类型擦除的 item；materialize 钩子在擦除点捕获，供 LogicWorld 物化
+/// （M2，见 [M2 LogicWorld](../../designs/m2/README.md)）。
+pub struct DynItem {
+    inner: Box<dyn AnyExtractCoreItem>,
+    materialize: fn(Self, &mut MaterializeCtx, u32),
+}
 ```
 
 `SceneEvaluator::sample_at(render_secs, out)` 对根 Stack 的每个顶层 cell 求值，

--- a/examples/agents/double_pendulum/lib.rs
+++ b/examples/agents/double_pendulum/lib.rs
@@ -116,7 +116,7 @@ impl DoublePendulum {
 
 /// The full scene state: `N_PENDULUMS` near-identical pendulums plus the
 /// recent tip trajectories used for the fading trails.
-#[derive(Clone)]
+#[derive(ranim::bevy_ecs::component::Component, Clone)]
 struct ChaosState {
     pendulums: [DoublePendulum; N_PENDULUMS],
     trails: [Vec<DVec3>; N_PENDULUMS],
@@ -228,6 +228,8 @@ impl Extract for ChaosState {
         pivot_dot.extract_into(buf);
     }
 }
+
+impl ranim::core::logic::LogicItem for ChaosState {}
 
 #[scene]
 #[wasm_demo_doc]

--- a/examples/cloth_wrap/lib.rs
+++ b/examples/cloth_wrap/lib.rs
@@ -38,7 +38,7 @@ const BALL_START_Y: f64 = 3.0;
 const BALL_STOP_Y: f64 = 1.4;
 
 /// The cloth-plus-ball system's full state.
-#[derive(Clone)]
+#[derive(ranim::bevy_ecs::component::Component, Clone)]
 struct ClothState {
     curr: Vec<DVec3>,
     prev: Vec<DVec3>,
@@ -218,6 +218,8 @@ impl Extract for ClothState {
         ball.extract_into(buf);
     }
 }
+
+impl ranim::core::logic::LogicItem for ClothState {}
 
 #[scene]
 #[wasm_demo_doc]

--- a/examples/extract_vitem_visualize/lib.rs
+++ b/examples/extract_vitem_visualize/lib.rs
@@ -110,7 +110,7 @@ pub fn hello_ranim(r: &mut RanimScene) {
     );
 }
 
-#[derive(Clone)]
+#[derive(ranim::bevy_ecs::component::Component, Clone)]
 pub struct VisualVItem(VItem);
 
 impl Interpolatable for VisualVItem {
@@ -249,6 +249,8 @@ impl Extract for VisualVItem {
             });
     }
 }
+
+impl ranim::core::logic::LogicItem for VisualVItem {}
 
 impl Empty for VisualVItem {
     fn empty() -> Self {

--- a/examples/iterative_spring/lib.rs
+++ b/examples/iterative_spring/lib.rs
@@ -21,7 +21,7 @@ use ranim::{
 };
 
 /// The spring's state: displacement and velocity.
-#[derive(Clone)]
+#[derive(ranim::bevy_ecs::component::Component, Clone)]
 struct SpringState {
     x: f64,
     v: f64,
@@ -38,6 +38,8 @@ impl Extract for SpringState {
         ball.extract_into(buf);
     }
 }
+
+impl ranim::core::logic::LogicItem for SpringState {}
 
 const K: f64 = 25.0;
 const C: f64 = 1.0;

--- a/examples/nbody/lib.rs
+++ b/examples/nbody/lib.rs
@@ -44,7 +44,7 @@ struct Body {
 }
 
 /// The N-body system's full state.
-#[derive(Clone)]
+#[derive(ranim::bevy_ecs::component::Component, Clone)]
 struct NBodyState {
     bodies: Vec<Body>,
     trails: Vec<Vec<DVec3>>,
@@ -152,6 +152,8 @@ impl Extract for NBodyState {
         }
     }
 }
+
+impl ranim::core::logic::LogicItem for NBodyState {}
 
 #[scene]
 #[wasm_demo_doc]

--- a/packages/ranim-cli/src/cli/inspect.rs
+++ b/packages/ranim-cli/src/cli/inspect.rs
@@ -455,7 +455,7 @@ fn frame_command(
     let scene = select_scene(lib, Some(scene_name))?;
     let sealed = scene.constructor.build_scene();
     let total_secs = sealed.total_secs();
-    let mut evaluator = sealed.into_evaluator(120.0);
+    let mut evaluator = sealed.into_evaluator();
     let infos = evaluator.animation_infos();
     let mut frame = EvaluatedFrame::new();
     evaluator.sample_at(at, &mut frame);

--- a/packages/ranim-core/src/animation/eval.rs
+++ b/packages/ranim-core/src/animation/eval.rs
@@ -9,10 +9,7 @@
 //!
 //! [`AnimationCell`]: super::AnimationCell
 
-use crate::{
-    core_item::DynItem,
-    logic::{MaterializeCtx, MaterializeOut, upsert_item},
-};
+use crate::{core_item::DynItem, logic::MaterializeOut};
 
 use super::{AnimationInfo, AnimationInfoKind};
 
@@ -89,14 +86,6 @@ pub(super) trait EvalDyn {
     /// content coordinates and recurse into their active children.
     fn eval_dyn(&self, _alpha: f64, _output: &mut Vec<DynItem>) {}
 
-    /// Materialize this node's typed output into the `LogicWorld` (M2 stage 1).
-    ///
-    /// The typed twin of [`eval_dyn`](EvalDyn::eval_dyn): leaves evaluate at
-    /// `alpha` and upsert their `Output` as a typed component at the current
-    /// identity slot; containers forward to their active children. Default
-    /// no-op for nodes without a typed output.
-    fn materialize_dyn(&self, _alpha: f64, _ctx: &mut MaterializeCtx) {}
-
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Eval
     }
@@ -122,27 +111,6 @@ impl EvalDyn for StaticDynItems {
         output.extend(self.0.iter().cloned());
     }
 
-    fn materialize_dyn(&self, _alpha: f64, ctx: &mut MaterializeCtx) {
-        // Best effort for the core item family (already `LogicItem`); other
-        // static outputs are skipped until they become components (TODO M2).
-        use crate::core_item::{camera_frame::CameraFrame, mesh_item::MeshItem, vitem::VItem};
-        use std::any::Any;
-        for item in &self.0 {
-            let any: &dyn Any = item.0.as_ref();
-            let part = ctx.part;
-            if let Some(v) = any.downcast_ref::<VItem>() {
-                ctx.part += 1;
-                upsert_item(ctx, part, v.clone());
-            } else if let Some(m) = any.downcast_ref::<MeshItem>() {
-                ctx.part += 1;
-                upsert_item(ctx, part, m.clone());
-            } else if let Some(c) = any.downcast_ref::<CameraFrame>() {
-                ctx.part += 1;
-                upsert_item(ctx, part, c.clone());
-            }
-        }
-    }
-
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Static
     }
@@ -158,13 +126,7 @@ where
     E::Output: MaterializeOut,
 {
     fn eval_dyn(&self, alpha: f64, output: &mut Vec<DynItem>) {
-        output.push(DynItem(Box::new(self.eval_alpha(alpha))));
-    }
-
-    fn materialize_dyn(&self, alpha: f64, ctx: &mut MaterializeCtx) {
-        let part = ctx.part;
-        ctx.part += 1;
-        self.eval_alpha(alpha).materialize(ctx, part);
+        output.push(DynItem::new(self.eval_alpha(alpha)));
     }
 
     fn sim_step(&self) -> Option<f64> {

--- a/packages/ranim-core/src/animation/eval.rs
+++ b/packages/ranim-core/src/animation/eval.rs
@@ -9,7 +9,10 @@
 //!
 //! [`AnimationCell`]: super::AnimationCell
 
-use crate::core_item::{AnyExtractCoreItem, DynItem};
+use crate::{
+    core_item::DynItem,
+    logic::{MaterializeCtx, MaterializeOut, upsert_item},
+};
 
 use super::{AnimationInfo, AnimationInfoKind};
 
@@ -77,7 +80,7 @@ pub trait EvalExt: Eval + Sized {
 
 impl<E: Eval + Sized> EvalExt for E {}
 
-/// An auto implemented trait for erasing `Eval<Output = T>` where T: AnyExtractCoreItem
+/// An auto implemented trait for erasing `Eval<Output = T>` where T: MaterializeOut
 pub(super) trait EvalDyn {
     /// Evaluate this node's content at its own normalized progress `alpha`,
     /// pushing the resulting erased items into `output`.
@@ -85,6 +88,14 @@ pub(super) trait EvalDyn {
     /// Leaves evaluate/project at `alpha`; containers remap `alpha` into their
     /// content coordinates and recurse into their active children.
     fn eval_dyn(&self, _alpha: f64, _output: &mut Vec<DynItem>) {}
+
+    /// Materialize this node's typed output into the `LogicWorld` (M2 stage 1).
+    ///
+    /// The typed twin of [`eval_dyn`](EvalDyn::eval_dyn): leaves evaluate at
+    /// `alpha` and upsert their `Output` as a typed component at the current
+    /// identity slot; containers forward to their active children. Default
+    /// no-op for nodes without a typed output.
+    fn materialize_dyn(&self, _alpha: f64, _ctx: &mut MaterializeCtx) {}
 
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Eval
@@ -111,6 +122,27 @@ impl EvalDyn for StaticDynItems {
         output.extend(self.0.iter().cloned());
     }
 
+    fn materialize_dyn(&self, _alpha: f64, ctx: &mut MaterializeCtx) {
+        // Best effort for the core item family (already `LogicItem`); other
+        // static outputs are skipped until they become components (TODO M2).
+        use crate::core_item::{camera_frame::CameraFrame, mesh_item::MeshItem, vitem::VItem};
+        use std::any::Any;
+        for item in &self.0 {
+            let any: &dyn Any = item.0.as_ref();
+            let part = ctx.part;
+            if let Some(v) = any.downcast_ref::<VItem>() {
+                ctx.part += 1;
+                upsert_item(ctx, part, v.clone());
+            } else if let Some(m) = any.downcast_ref::<MeshItem>() {
+                ctx.part += 1;
+                upsert_item(ctx, part, m.clone());
+            } else if let Some(c) = any.downcast_ref::<CameraFrame>() {
+                ctx.part += 1;
+                upsert_item(ctx, part, c.clone());
+            }
+        }
+    }
+
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Static
     }
@@ -123,10 +155,16 @@ impl EvalDyn for StaticDynItems {
 impl<E> EvalDyn for E
 where
     E: Eval,
-    E::Output: AnyExtractCoreItem,
+    E::Output: MaterializeOut,
 {
     fn eval_dyn(&self, alpha: f64, output: &mut Vec<DynItem>) {
         output.push(DynItem(Box::new(self.eval_alpha(alpha))));
+    }
+
+    fn materialize_dyn(&self, alpha: f64, ctx: &mut MaterializeCtx) {
+        let part = ctx.part;
+        ctx.part += 1;
+        self.eval_alpha(alpha).materialize(ctx, part);
     }
 
     fn sim_step(&self) -> Option<f64> {

--- a/packages/ranim-core/src/animation/eval/iterative.rs
+++ b/packages/ranim-core/src/animation/eval/iterative.rs
@@ -269,7 +269,7 @@ mod tests {
                 .with_steps(240)
                 .with_duration(2.0),
             );
-            scene.seal().into_evaluator(120.0)
+            scene.seal().into_evaluator()
         }
 
         let run = || {

--- a/packages/ranim-core/src/animation/lagged.rs
+++ b/packages/ranim-core/src/animation/lagged.rs
@@ -185,15 +185,6 @@ impl EvalDyn for AnimLagged {
         }
     }
 
-    fn materialize_dyn(&self, alpha: f64, ctx: &mut crate::logic::MaterializeCtx) {
-        let content_sec = self.duration_secs * alpha;
-        for animation in &self.animations {
-            if animation.contains_sec(content_sec, self.duration_secs) {
-                animation.materialize_at(content_sec, ctx);
-            }
-        }
-    }
-
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Lagged
     }

--- a/packages/ranim-core/src/animation/lagged.rs
+++ b/packages/ranim-core/src/animation/lagged.rs
@@ -185,6 +185,15 @@ impl EvalDyn for AnimLagged {
         }
     }
 
+    fn materialize_dyn(&self, alpha: f64, ctx: &mut crate::logic::MaterializeCtx) {
+        let content_sec = self.duration_secs * alpha;
+        for animation in &self.animations {
+            if animation.contains_sec(content_sec, self.duration_secs) {
+                animation.materialize_at(content_sec, ctx);
+            }
+        }
+    }
+
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Lagged
     }

--- a/packages/ranim-core/src/animation/mod.rs
+++ b/packages/ranim-core/src/animation/mod.rs
@@ -125,19 +125,6 @@ impl AnimationCell {
         self.inner.eval_dyn(alpha, output);
     }
 
-    /// Materialize this cell's typed output into the `LogicWorld` (M2).
-    ///
-    /// The typed twin of [`eval_at`](Self::eval_at): same active check, same
-    /// rate-warped `alpha`, but the inner node upserts typed components into
-    /// the world instead of pushing erased items.
-    pub(crate) fn materialize_at(&self, sec: f64, ctx: &mut crate::logic::MaterializeCtx) {
-        if !self.enabled || !self.active_at(sec) {
-            return;
-        }
-        let alpha = self.local_alpha(sec);
-        self.inner.materialize_dyn(alpha, ctx);
-    }
-
     pub(in crate::animation) fn contains_sec(&self, sec: f64, parent_duration: f64) -> bool {
         self.time_range.contains(&sec) || (sec == parent_duration && sec == self.time_range.end)
     }

--- a/packages/ranim-core/src/animation/mod.rs
+++ b/packages/ranim-core/src/animation/mod.rs
@@ -2,10 +2,7 @@
 
 use std::{any::type_name, fmt::Debug, ops::Range};
 
-use crate::{
-    core_item::{AnyExtractCoreItem, DynItem},
-    utils::rate_functions::linear,
-};
+use crate::{core_item::DynItem, logic::MaterializeOut, utils::rate_functions::linear};
 
 /// Evaluation protocols and author-facing adapters.
 pub mod eval;
@@ -128,6 +125,19 @@ impl AnimationCell {
         self.inner.eval_dyn(alpha, output);
     }
 
+    /// Materialize this cell's typed output into the `LogicWorld` (M2).
+    ///
+    /// The typed twin of [`eval_at`](Self::eval_at): same active check, same
+    /// rate-warped `alpha`, but the inner node upserts typed components into
+    /// the world instead of pushing erased items.
+    pub(crate) fn materialize_at(&self, sec: f64, ctx: &mut crate::logic::MaterializeCtx) {
+        if !self.enabled || !self.active_at(sec) {
+            return;
+        }
+        let alpha = self.local_alpha(sec);
+        self.inner.materialize_dyn(alpha, ctx);
+    }
+
     pub(in crate::animation) fn contains_sec(&self, sec: f64, parent_duration: f64) -> bool {
         self.time_range.contains(&sec) || (sec == parent_duration && sec == self.time_range.end)
     }
@@ -189,13 +199,13 @@ impl<A: Placeable> AnimationExt for A {}
 impl<E> Placeable for E
 where
     E: Eval + 'static,
-    E::Output: AnyExtractCoreItem,
+    E::Output: MaterializeOut,
 {
 }
 impl<E> Animation for E
 where
     E: Eval + 'static,
-    E::Output: AnyExtractCoreItem,
+    E::Output: MaterializeOut,
 {
     fn build(self) -> AnimationCell {
         AnimationCell {
@@ -351,9 +361,9 @@ pub trait AnimIterExt: Iterator + Sized {
 impl<I: Iterator> AnimIterExt for I {}
 
 /// Requirement for [`StaticAnim`].
-pub trait StaticAnimRequirement: Clone + AnyExtractCoreItem {}
+pub trait StaticAnimRequirement: Clone + MaterializeOut {}
 
-impl<T: Clone + AnyExtractCoreItem> StaticAnimRequirement for T {}
+impl<T: Clone + MaterializeOut> StaticAnimRequirement for T {}
 
 /// Convenience methods for zero-duration static animations.
 pub trait StaticAnim: StaticAnimRequirement + Sized {

--- a/packages/ranim-core/src/animation/sequence.rs
+++ b/packages/ranim-core/src/animation/sequence.rs
@@ -159,6 +159,18 @@ impl EvalDyn for AnimSequence {
         }
     }
 
+    fn materialize_dyn(&self, alpha: f64, ctx: &mut crate::logic::MaterializeCtx) {
+        let content_sec = self.cursor_sec * alpha;
+        if let Some(child) = self
+            .animations
+            .iter()
+            .rev()
+            .find(|child| child.contains_sec(content_sec, self.cursor_sec))
+        {
+            child.materialize_at(content_sec, ctx);
+        }
+    }
+
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Sequence
     }

--- a/packages/ranim-core/src/animation/sequence.rs
+++ b/packages/ranim-core/src/animation/sequence.rs
@@ -159,18 +159,6 @@ impl EvalDyn for AnimSequence {
         }
     }
 
-    fn materialize_dyn(&self, alpha: f64, ctx: &mut crate::logic::MaterializeCtx) {
-        let content_sec = self.cursor_sec * alpha;
-        if let Some(child) = self
-            .animations
-            .iter()
-            .rev()
-            .find(|child| child.contains_sec(content_sec, self.cursor_sec))
-        {
-            child.materialize_at(content_sec, ctx);
-        }
-    }
-
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Sequence
     }

--- a/packages/ranim-core/src/animation/stack.rs
+++ b/packages/ranim-core/src/animation/stack.rs
@@ -77,15 +77,6 @@ impl EvalDyn for AnimStack {
         }
     }
 
-    fn materialize_dyn(&self, alpha: f64, ctx: &mut crate::logic::MaterializeCtx) {
-        let content_sec = self.duration_secs * alpha;
-        for child in &self.animations {
-            if child.contains_sec(content_sec, self.duration_secs) {
-                child.materialize_at(content_sec, ctx);
-            }
-        }
-    }
-
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Stack
     }

--- a/packages/ranim-core/src/animation/stack.rs
+++ b/packages/ranim-core/src/animation/stack.rs
@@ -77,6 +77,15 @@ impl EvalDyn for AnimStack {
         }
     }
 
+    fn materialize_dyn(&self, alpha: f64, ctx: &mut crate::logic::MaterializeCtx) {
+        let content_sec = self.duration_secs * alpha;
+        for child in &self.animations {
+            if child.contains_sec(content_sec, self.duration_secs) {
+                child.materialize_at(content_sec, ctx);
+            }
+        }
+    }
+
     fn info_kind(&self) -> AnimationInfoKind {
         AnimationInfoKind::Stack
     }

--- a/packages/ranim-core/src/core_item/mod.rs
+++ b/packages/ranim-core/src/core_item/mod.rs
@@ -13,6 +13,7 @@ use dyn_clone::DynClone;
 use crate::{
     Extract,
     core_item::{camera_frame::CameraFrame, mesh_item::MeshItem, vitem::VItem},
+    logic::{MaterializeCtx, MaterializeOut},
 };
 
 /// Camera frame
@@ -39,13 +40,47 @@ impl<T: Extract<Target = CoreItem> + Any + DynClone> AnyExtractCoreItem for T {}
 
 dyn_clone::clone_trait_object!(AnyExtractCoreItem);
 
-/// A dynamic item, basically type erased [`AnyExtractCoreItem`]
+/// A dynamic item: a type-erased [`AnyExtractCoreItem`] carrying its own
+/// materialize hook (M2).
+///
+/// The hook is monomorphized at the single erasure point ([`DynItem::new`]):
+/// it downcasts back to the concrete type and upserts the value into the
+/// `LogicWorld`. A `DynItem` can therefore materialize itself without the
+/// host knowing its type — including items captured into static cells
+/// (`hold`, lagged fills), where the concrete type is otherwise lost.
 #[derive(Clone)]
-pub struct DynItem(pub Box<dyn AnyExtractCoreItem>);
+pub struct DynItem {
+    inner: Box<dyn AnyExtractCoreItem>,
+    materialize: fn(Self, &mut MaterializeCtx, u32),
+}
+
+/// Materialize hook for `T`, monomorphized at [`DynItem`] construction.
+fn materialize_hook<T: MaterializeOut>(item: DynItem, ctx: &mut MaterializeCtx, part: u32) {
+    let any: Box<dyn Any> = item.inner;
+    let typed = any
+        .downcast::<T>()
+        .expect("DynItem materialize hook type mismatch");
+    typed.materialize(ctx, part);
+}
+
+impl DynItem {
+    /// Erase a materializable item, capturing its typed materialize hook.
+    pub fn new<T: MaterializeOut>(item: T) -> Self {
+        Self {
+            inner: Box::new(item),
+            materialize: materialize_hook::<T>,
+        }
+    }
+
+    /// Materialize into the `LogicWorld` at the given `part` slot (M2).
+    pub(crate) fn materialize(self, ctx: &mut MaterializeCtx, part: u32) {
+        (self.materialize)(self, ctx, part);
+    }
+}
 
 impl Extract for DynItem {
     type Target = CoreItem;
     fn extract_into(&self, buf: &mut Vec<Self::Target>) {
-        self.0.extract_into(buf);
+        self.inner.extract_into(buf);
     }
 }

--- a/packages/ranim-core/src/lib.rs
+++ b/packages/ranim-core/src/lib.rs
@@ -202,11 +202,8 @@ pub struct SealedRanimScene {
 
 impl SealedRanimScene {
     /// Consume this scene into a [`SceneEvaluator`] driving session.
-    ///
-    /// `logic_fps` is retained for call-site compatibility; it no longer drives
-    /// stepping (each iterative segment owns its own `sim_step`).
-    pub fn into_evaluator(self, logic_fps: f64) -> SceneEvaluator {
-        SceneEvaluator::new(self, logic_fps)
+    pub fn into_evaluator(self) -> SceneEvaluator {
+        SceneEvaluator::new(self)
     }
 
     /// Total scene duration.

--- a/packages/ranim-core/src/lib.rs
+++ b/packages/ranim-core/src/lib.rs
@@ -17,12 +17,15 @@ pub mod color;
 pub mod components;
 /// Fundamental scene primitives.
 pub mod core_item;
+/// Logic-side ECS World (M2): retained `LogicWorld` + `ScenePlayer` driver.
+pub mod logic;
 /// Scene evaluation driver (lightweight session, no ECS).
 pub mod scene_evaluator;
 /// Time vocabulary for animation evaluation.
 pub mod time;
 /// Fundamental traits.
 pub mod traits;
+pub use logic::ScenePlayer;
 pub use scene_evaluator::SceneEvaluator;
 /// Utilities.
 pub mod utils;

--- a/packages/ranim-core/src/lib.rs
+++ b/packages/ranim-core/src/lib.rs
@@ -26,7 +26,7 @@ pub mod time;
 /// Fundamental traits.
 pub mod traits;
 pub use logic::ScenePlayer;
-pub use scene_evaluator::SceneEvaluator;
+pub use scene_evaluator::{EvaluatedFrame, SceneEvaluator, SceneSession};
 /// Utilities.
 pub mod utils;
 

--- a/packages/ranim-core/src/logic.rs
+++ b/packages/ranim-core/src/logic.rs
@@ -69,6 +69,16 @@ impl<T: Extract<Target = CoreItem>> Extract for Batch<T> {
 /// - single items (`T: LogicItem`) upsert a typed component;
 /// - `Vec<T>` (group outputs) upsert a [`Batch<T>`] component holding the
 ///   whole vector as one entity.
+///
+/// Every implementation follows the same split (the dylib rule):
+///
+/// - **host-side** (via the fn pointer in [`MaterializeCtx`]): identity,
+///   order, and [`ExtractedItems`] components — these must be registered by
+///   the binary that owns the world, because component registration is
+///   keyed by `TypeId`, which differs across a dylib boundary;
+/// - **hook-side** (wherever the hook was monomorphized): extraction of the
+///   owned value and insertion of the typed component `T` — `TypeId`-sensitive
+///   operations on `T` are only valid on the side that knows `T`.
 pub trait MaterializeOut: AnyExtractCoreItem + Send + Sync + 'static {
     /// Materialize this output at the given slot.
     fn materialize(self, ctx: &mut MaterializeCtx, part: u32);
@@ -76,13 +86,35 @@ pub trait MaterializeOut: AnyExtractCoreItem + Send + Sync + 'static {
 
 impl<T: LogicItem> MaterializeOut for T {
     fn materialize(self, ctx: &mut MaterializeCtx, part: u32) {
-        upsert_item(ctx, part, self);
+        respawn_on_type_change::<T>(ctx, part);
+        let mut extracted = Vec::new();
+        self.extract_into(&mut extracted);
+        let entity = (ctx.upsert)(ctx, part, extracted);
+        ctx.world.entity_mut(entity).insert(self);
     }
 }
 
 impl<T: LogicItem + Clone> MaterializeOut for Vec<T> {
     fn materialize(self, ctx: &mut MaterializeCtx, part: u32) {
-        upsert_item(ctx, part, Batch(self));
+        respawn_on_type_change::<Batch<T>>(ctx, part);
+        let mut extracted = Vec::new();
+        self.extract_into(&mut extracted);
+        let entity = (ctx.upsert)(ctx, part, extracted);
+        ctx.world.entity_mut(entity).insert(Batch(self));
+    }
+}
+
+/// Respawn the slot's entity when its stored component type differs from the
+/// incoming one (e.g. a sequence switched to a child segment whose output
+/// type differs), so no stale typed component lingers. Checked hook-side,
+/// where the `TypeId` of `T` matches the side that inserted it.
+fn respawn_on_type_change<T: Component>(ctx: &mut MaterializeCtx, part: u32) {
+    let key = (ctx.animation_id, part);
+    if let Some(&entity) = ctx.index.get(&key)
+        && !ctx.world.entity(entity).contains::<T>()
+    {
+        ctx.world.despawn(entity);
+        ctx.index.remove(&key);
     }
 }
 
@@ -125,6 +157,14 @@ pub struct ExtractedItems(pub Vec<CoreItem>);
 /// output slots within the current top-level cell; every leaf materialization
 /// occupies exactly one slot (multiple extracted `CoreItem`s within a slot
 /// are expanded at collect time).
+///
+/// `upsert` is a fn pointer to host-side code (set by [`ScenePlayer`] when
+/// the context is created): the world write for host-known components
+/// ([`ItemIdentity`], [`SceneOrder`], [`ExtractedItems`]) must execute in the
+/// binary that owns the world, because bevy component registration is keyed
+/// by `TypeId`, which differs across a dylib boundary. Hooks monomorphized
+/// in a dylib call it indirectly and therefore always upsert host-registered
+/// components (the embryonic stage-3 registry shape).
 pub struct MaterializeCtx<'w> {
     /// The world being materialized into.
     pub world: &'w mut World,
@@ -136,53 +176,40 @@ pub struct MaterializeCtx<'w> {
     pub part: u32,
     /// Keys materialized this frame (drives despawn of stale entities).
     pub seen: &'w mut HashSet<(u32, u32)>,
+    /// Host-side slot upsert (see the type-level docs).
+    pub upsert: fn(&mut MaterializeCtx<'_>, u32, Vec<CoreItem>) -> Entity,
 }
 
-/// Upsert a typed item component at the given `part` slot of the current
-/// `animation_id`: create the entity on first appearance, replace the
-/// component afterwards, and record the key as seen this frame.
-///
-/// Extraction is fused into the upsert: while the typed value is still owned,
-/// its `CoreItem`s are produced into the entity's retained
-/// [`ExtractedItems`] buffer — one clone per item per frame, same as the
-/// pure path, with no separate extract pass.
-///
-/// If the slot already exists but holds a *different* component type (e.g. a
-/// sequence switched to a child segment whose output type differs), the stale
-/// entity is despawned and respawned so the stored component always matches
-/// the slot's current type.
-pub(crate) fn upsert_item<T: LogicItem>(ctx: &mut MaterializeCtx, part: u32, value: T) {
+/// Host-side slot upsert: create the entity on first appearance (with
+/// host-registered identity/order/extraction components), replace the
+/// extraction buffer afterwards, and record the key as seen this frame.
+fn upsert_slot(ctx: &mut MaterializeCtx, part: u32, extracted: Vec<CoreItem>) -> Entity {
     let key = (ctx.animation_id, part);
     let entity = match ctx.index.get(&key) {
-        Some(&entity) if ctx.world.entity(entity).contains::<T>() => entity,
-        existing => {
-            if let Some(&entity) = existing {
-                ctx.world.despawn(entity);
-            }
+        Some(&entity) => {
             ctx.world
-                .spawn((
-                    ItemIdentity {
-                        animation_id: key.0,
-                        part: key.1,
-                    },
-                    SceneOrder {
-                        animation_id: key.0,
-                        part: key.1,
-                    },
-                    ExtractedItems::default(),
-                ))
-                .id()
+                .entity_mut(entity)
+                .insert(ExtractedItems(extracted));
+            entity
         }
+        None => ctx
+            .world
+            .spawn((
+                ItemIdentity {
+                    animation_id: key.0,
+                    part: key.1,
+                },
+                SceneOrder {
+                    animation_id: key.0,
+                    part: key.1,
+                },
+                ExtractedItems(extracted),
+            ))
+            .id(),
     };
-    let mut entity_mut = ctx.world.entity_mut(entity);
-    {
-        let mut extracted = entity_mut.get_mut::<ExtractedItems>().unwrap();
-        extracted.0.clear();
-        value.extract_into(&mut extracted.0);
-    }
-    entity_mut.insert(value);
     ctx.index.insert(key, entity);
     ctx.seen.insert(key);
+    entity
 }
 
 /// The M2 driving session: owns the retained `LogicWorld` and materializes
@@ -245,6 +272,18 @@ impl ScenePlayer {
         self.index.len()
     }
 
+    /// Take the `LogicWorld` out for render-side direct extraction (world
+    /// exchange): the render side reconciles from it and hands it back via
+    /// [`put_world`](Self::put_world) before the next `materialize_at`.
+    pub fn take_world(&mut self) -> World {
+        std::mem::replace(&mut self.world, World::new())
+    }
+
+    /// Put the `LogicWorld` back after render-side direct extraction.
+    pub fn put_world(&mut self, world: World) {
+        self.world = world;
+    }
+
     /// Materialize the scene at `render_secs` into the `LogicWorld`: every
     /// active cell evaluates (the same pure query as the render path) and
     /// each resulting [`DynItem`](crate::core_item::DynItem) upserts itself
@@ -265,6 +304,7 @@ impl ScenePlayer {
                 animation_id: animation_id as u32,
                 part: 0,
                 seen: &mut seen,
+                upsert: upsert_slot,
             };
             for item in items {
                 let part = ctx.part;

--- a/packages/ranim-core/src/logic.rs
+++ b/packages/ranim-core/src/logic.rs
@@ -9,14 +9,16 @@
 //!   monomorphized at its single erasure point, so the materialize phase is
 //!   just the shared `eval` traversal followed by each item upserting itself
 //!   by a stable `(animation_id, part)` identity (E4-validated pattern);
-//! - the per-entity [`ItemExtractor`] fn pointer is written by the typed
-//!   materializer, so the driver can extract every item without naming its
-//!   type (no global registry needed in-process);
+//! - extraction is **fused into the upsert**: while the typed value is still
+//!   owned, its `CoreItem`s go straight into the entity's retained
+//!   [`ExtractedItems`] buffer — one clone per item per frame, same as the
+//!   pure path, with no separate extract pass;
 //! - [`ScenePlayer`] is the M2 driver: the retained-world counterpart of
 //!   [`SceneEvaluator`](crate::SceneEvaluator). Evaluation is a pure query
 //!   (`eval_alpha`), so there is no stepping or seek bookkeeping to mirror —
-//!   `materialize_at → extract → collect` produces a
-//!   [`EvaluatedFrame`](crate::EvaluatedFrame) identical to the pure path.
+//!   `materialize_at` (upsert with extraction fused in) plus `collect`
+//!   (drain) produces an [`EvaluatedFrame`](crate::EvaluatedFrame) identical
+//!   to the pure path.
 //!
 //! The render side is untouched: collect emits `((animation_id, part), CoreItem)`
 //! exactly like the pre-ECS path, so `RenderWorld` reconciliation keeps working.
@@ -108,27 +110,14 @@ pub struct SceneOrder {
     pub part: u32,
 }
 
-/// Type-erased per-entity extractor, written by the typed materializer.
+/// Per-entity extraction output, written at materialize time while the typed
+/// value is still owned (stage-2 `Extracted<T>` will generalize this).
 ///
-/// The driver calls this to degrade the item component to `CoreItem`s without
-/// naming its type. In-process this is a plain fn pointer; the dylib path
-/// (stage 3) uses the same shape through a global registry instead.
-#[derive(Component, Clone, Copy)]
-pub struct ItemExtractor(pub fn(Entity, &World, &mut Vec<CoreItem>));
-
-/// Per-entity extraction output. The `Vec` is retained across frames so its
-/// allocation is reused (stage-2 `Extracted<T>` will generalize this).
+/// The `Vec` is retained across frames so its allocation is reused: the
+/// materialize phase refills it (`clear` + `extract_into`), and the collect
+/// phase drains it into the frame buffer (move, not clone).
 #[derive(Component, Default)]
 pub struct ExtractedItems(pub Vec<CoreItem>);
-
-/// Build the type-erased extractor for `T` (monomorphized at the typed site).
-fn extractor_of<T: LogicItem>() -> fn(Entity, &World, &mut Vec<CoreItem>) {
-    |entity, world, out| {
-        if let Some(item) = world.entity(entity).get::<T>() {
-            item.extract_into(out);
-        }
-    }
-}
 
 /// Materialization context threaded down the cell tree.
 ///
@@ -153,17 +142,19 @@ pub struct MaterializeCtx<'w> {
 /// `animation_id`: create the entity on first appearance, replace the
 /// component afterwards, and record the key as seen this frame.
 ///
+/// Extraction is fused into the upsert: while the typed value is still owned,
+/// its `CoreItem`s are produced into the entity's retained
+/// [`ExtractedItems`] buffer — one clone per item per frame, same as the
+/// pure path, with no separate extract pass.
+///
 /// If the slot already exists but holds a *different* component type (e.g. a
 /// sequence switched to a child segment whose output type differs), the stale
-/// entity is despawned and respawned so its [`ItemExtractor`] always matches
-/// the component actually stored.
+/// entity is despawned and respawned so the stored component always matches
+/// the slot's current type.
 pub(crate) fn upsert_item<T: LogicItem>(ctx: &mut MaterializeCtx, part: u32, value: T) {
     let key = (ctx.animation_id, part);
     let entity = match ctx.index.get(&key) {
-        Some(&entity) if ctx.world.entity(entity).contains::<T>() => {
-            ctx.world.entity_mut(entity).insert(value);
-            entity
-        }
+        Some(&entity) if ctx.world.entity(entity).contains::<T>() => entity,
         existing => {
             if let Some(&entity) = existing {
                 ctx.world.despawn(entity);
@@ -178,13 +169,18 @@ pub(crate) fn upsert_item<T: LogicItem>(ctx: &mut MaterializeCtx, part: u32, val
                         animation_id: key.0,
                         part: key.1,
                     },
-                    ItemExtractor(extractor_of::<T>()),
                     ExtractedItems::default(),
-                    value,
                 ))
                 .id()
         }
     };
+    let mut entity_mut = ctx.world.entity_mut(entity);
+    {
+        let mut extracted = entity_mut.get_mut::<ExtractedItems>().unwrap();
+        extracted.0.clear();
+        value.extract_into(&mut extracted.0);
+    }
+    entity_mut.insert(value);
     ctx.index.insert(key, entity);
     ctx.seen.insert(key);
 }
@@ -290,29 +286,13 @@ impl ScenePlayer {
         self.clock = render_secs;
     }
 
-    /// Extract every live item to `CoreItem`s via its per-entity extractor.
-    pub fn extract(&mut self) {
-        let entities: Vec<Entity> = self
-            .world
-            .iter_entities()
-            .filter(|eref| eref.get::<ItemExtractor>().is_some())
-            .map(|eref| eref.id())
-            .collect();
-        for entity in entities {
-            let extractor = self.world.entity(entity).get::<ItemExtractor>().unwrap().0;
-            let mut buf = Vec::new();
-            extractor(entity, &self.world, &mut buf);
-            if let Some(mut extracted) = self.world.entity_mut(entity).get_mut::<ExtractedItems>() {
-                extracted.0 = buf;
-            }
-        }
-    }
-
     /// Collect the extracted items into an [`EvaluatedFrame`](crate::EvaluatedFrame)
-    /// sorted by scene order. The frame identity `(animation_id, part)` uses
-    /// the same flattened part indexing as the pure path, so output is
+    /// sorted by scene order, **draining** each entity's [`ExtractedItems`]
+    /// buffer (the elements are moved into `out`, the allocation stays for
+    /// the next frame). The frame identity `(animation_id, part)` uses the
+    /// same flattened part indexing as the pure path, so output is
     /// frame-identical and the renderer needs no changes.
-    pub fn collect(&self, out: &mut EvaluatedFrame) {
+    pub fn collect(&mut self, out: &mut EvaluatedFrame) {
         let mut ordered: Vec<(SceneOrder, Entity)> = Vec::new();
         for eref in self.world.iter_entities() {
             let Some(order) = eref.get::<SceneOrder>() else {
@@ -332,22 +312,28 @@ impl ScenePlayer {
                 current_animation = Some(order.animation_id);
                 flat_part = 0;
             }
-            let Some(extracted) = self.world.entity(entity).get::<ExtractedItems>() else {
+            let mut entity_mut = self.world.entity_mut(entity);
+            let Some(mut extracted) = entity_mut.get_mut::<ExtractedItems>() else {
                 continue;
             };
-            for core in &extracted.0 {
-                out.push(((order.animation_id as usize, flat_part), core.clone()));
-                flat_part += 1;
-            }
+            let animation_id = order.animation_id as usize;
+            let len = extracted.0.len();
+            out.extend(
+                extracted
+                    .0
+                    .drain(..)
+                    .enumerate()
+                    .map(|(i, core)| ((animation_id, flat_part + i), core)),
+            );
+            flat_part += len;
         }
     }
 
-    /// One frame: materialize at `render_secs`, then extract → collect into
-    /// `out`. Convenience wrapper mirroring the pure path's
+    /// One frame: materialize at `render_secs` (upsert + extract fused), then
+    /// collect into `out`. Convenience wrapper mirroring the pure path's
     /// [`SceneEvaluator::sample_at`](crate::SceneEvaluator::sample_at).
     pub fn frame(&mut self, render_secs: f64, out: &mut EvaluatedFrame) {
         self.materialize_at(render_secs);
-        self.extract();
         self.collect(out);
     }
 }

--- a/packages/ranim-core/src/logic.rs
+++ b/packages/ranim-core/src/logic.rs
@@ -26,10 +26,10 @@ use std::collections::{HashMap, HashSet};
 use bevy_ecs::{component::Component, entity::Entity, world::World};
 
 use crate::{
-    Extract, SealedRanimScene,
-    animation::AnimationCell,
+    Extract, SealedRanimScene, TimeMark,
+    animation::{AnimationCell, AnimationInfo},
     core_item::{AnyExtractCoreItem, CoreItem},
-    scene_evaluator::EvaluatedFrame,
+    scene_evaluator::{EvaluatedFrame, SceneSession},
 };
 
 /// A top-level item that can live in the `LogicWorld` as a typed component.
@@ -203,6 +203,7 @@ pub struct ScenePlayer {
     /// `(animation_id, part)` → entity, the cross-frame identity index.
     index: HashMap<(u32, u32), Entity>,
     total_secs: f64,
+    time_marks: Vec<(f64, TimeMark)>,
     clock: f64,
 }
 
@@ -215,6 +216,7 @@ impl ScenePlayer {
             world: World::new(),
             index: HashMap::new(),
             total_secs: scene.total_secs,
+            time_marks: scene.time_marks,
             clock: 0.0,
         }
     }
@@ -227,6 +229,19 @@ impl ScenePlayer {
     /// Last materialized target time.
     pub fn clock(&self) -> f64 {
         self.clock
+    }
+
+    /// Scene time marks.
+    pub fn time_marks(&self) -> &[(f64, TimeMark)] {
+        &self.time_marks
+    }
+
+    /// Hierarchical runtime animation information for preview tooling.
+    pub fn animation_infos(&self) -> Vec<AnimationInfo> {
+        self.cells
+            .iter()
+            .map(AnimationCell::animation_info)
+            .collect()
     }
 
     /// Number of live item entities in the `LogicWorld`.
@@ -334,6 +349,32 @@ impl ScenePlayer {
         self.materialize_at(render_secs);
         self.extract();
         self.collect(out);
+    }
+}
+
+impl SceneSession for ScenePlayer {
+    fn from_sealed(scene: SealedRanimScene, _logic_fps: f64) -> Self {
+        Self::new(scene)
+    }
+
+    fn total_secs(&self) -> f64 {
+        self.total_secs()
+    }
+
+    fn clock(&self) -> f64 {
+        self.clock()
+    }
+
+    fn time_marks(&self) -> &[(f64, TimeMark)] {
+        self.time_marks()
+    }
+
+    fn animation_infos(&self) -> Vec<AnimationInfo> {
+        self.animation_infos()
+    }
+
+    fn sample_at(&mut self, render_secs: f64, out: &mut EvaluatedFrame) {
+        self.frame(render_secs, out);
     }
 }
 

--- a/packages/ranim-core/src/logic.rs
+++ b/packages/ranim-core/src/logic.rs
@@ -353,7 +353,7 @@ impl ScenePlayer {
 }
 
 impl SceneSession for ScenePlayer {
-    fn from_sealed(scene: SealedRanimScene, _logic_fps: f64) -> Self {
+    fn from_sealed(scene: SealedRanimScene) -> Self {
         Self::new(scene)
     }
 
@@ -421,7 +421,7 @@ mod tests {
     /// The world path must produce frame-identical output to the pure path.
     #[test]
     fn player_output_matches_evaluator() {
-        let mut ev = build().into_evaluator(120.0);
+        let mut ev = build().into_evaluator();
         let mut pl = ScenePlayer::new(build());
 
         for t in [0.0, 0.3, 0.7, 1.0, 1.2, 1.8, 2.5, 3.0] {
@@ -521,7 +521,7 @@ mod tests {
             scene.seal()
         }
 
-        let mut ev = build_hold().into_evaluator(120.0);
+        let mut ev = build_hold().into_evaluator();
         let mut pl = ScenePlayer::new(build_hold());
         for t in [0.5, 1.0, 1.5, 2.0] {
             let mut frame_ev = Vec::new();

--- a/packages/ranim-core/src/logic.rs
+++ b/packages/ranim-core/src/logic.rs
@@ -4,9 +4,11 @@
 //! Stage 1 establishes the (b)-architecture foundation:
 //!
 //! - items are **typed bevy components** (`LogicItem` = `Component` + `Extract`);
-//! - materialization happens at the **typed layer** — each `Eval` leaf samples
-//!   its `Output` and upserts it into the host-owned `World` by a stable
-//!   `(animation_id, part)` identity (E4-validated pattern);
+//! - materialization is **self-describing at the output layer** — every
+//!   [`DynItem`](crate::core_item::DynItem) carries a materialize hook
+//!   monomorphized at its single erasure point, so the materialize phase is
+//!   just the shared `eval` traversal followed by each item upserting itself
+//!   by a stable `(animation_id, part)` identity (E4-validated pattern);
 //! - the per-entity [`ItemExtractor`] fn pointer is written by the typed
 //!   materializer, so the driver can extract every item without naming its
 //!   type (no global registry needed in-process);
@@ -233,13 +235,17 @@ impl ScenePlayer {
     }
 
     /// Materialize the scene at `render_secs` into the `LogicWorld`: every
-    /// active cell evaluates and upserts its typed item components by
-    /// identity; entities whose identity no longer appears are despawned
-    /// ("entity lifetime = producer lifetime").
+    /// active cell evaluates (the same pure query as the render path) and
+    /// each resulting [`DynItem`](crate::core_item::DynItem) upserts itself
+    /// as a typed component via its captured materialize hook; entities whose
+    /// identity no longer appears are despawned ("entity lifetime = producer
+    /// lifetime").
     pub fn materialize_at(&mut self, render_secs: f64) {
         let mut seen = HashSet::new();
         for (animation_id, cell) in self.cells.iter().enumerate() {
-            if !cell.active_at(render_secs) {
+            let mut items = Vec::new();
+            cell.eval_at(render_secs, &mut items);
+            if items.is_empty() {
                 continue;
             }
             let mut ctx = MaterializeCtx {
@@ -249,7 +255,11 @@ impl ScenePlayer {
                 part: 0,
                 seen: &mut seen,
             };
-            cell.materialize_at(render_secs, &mut ctx);
+            for item in items {
+                let part = ctx.part;
+                ctx.part += 1;
+                item.materialize(&mut ctx, part);
+            }
         }
         let stale: Vec<(u32, u32)> = self
             .index
@@ -453,5 +463,31 @@ mod tests {
         pl.frame(1.5, &mut frame);
         assert_eq!(frame.len(), 1);
         assert!(matches!(frame[0].1, CoreItem::MeshItem(_)));
+    }
+
+    /// A held static snapshot is type-erased at capture time; the DynItem
+    /// hook must still materialize it correctly (frame-identical to the
+    /// pure path).
+    #[test]
+    fn held_static_snapshot_materializes() {
+        use crate::animation::sequence::AnimSequence;
+
+        fn build_hold() -> SealedRanimScene {
+            let mut scene = RanimScene::new();
+            let mut s = AnimSequence::new();
+            s.push(MoveX.with_duration(1.0)).hold(1.0);
+            scene.play(s);
+            scene.seal()
+        }
+
+        let mut ev = build_hold().into_evaluator(120.0);
+        let mut pl = ScenePlayer::new(build_hold());
+        for t in [0.5, 1.0, 1.5, 2.0] {
+            let mut frame_ev = Vec::new();
+            ev.sample_at(t, &mut frame_ev);
+            let mut frame_pl = Vec::new();
+            pl.frame(t, &mut frame_pl);
+            assert_eq!(frame_pl, frame_ev, "frame mismatch at t = {t}");
+        }
     }
 }

--- a/packages/ranim-core/src/logic.rs
+++ b/packages/ranim-core/src/logic.rs
@@ -1,0 +1,457 @@
+//! Logic-side ECS World (M2 stage 1): a retained `LogicWorld` driven by
+//! [`ScenePlayer`].
+//!
+//! Stage 1 establishes the (b)-architecture foundation:
+//!
+//! - items are **typed bevy components** (`LogicItem` = `Component` + `Extract`);
+//! - materialization happens at the **typed layer** — each `Eval` leaf samples
+//!   its `Output` and upserts it into the host-owned `World` by a stable
+//!   `(animation_id, part)` identity (E4-validated pattern);
+//! - the per-entity [`ItemExtractor`] fn pointer is written by the typed
+//!   materializer, so the driver can extract every item without naming its
+//!   type (no global registry needed in-process);
+//! - [`ScenePlayer`] is the M2 driver: the retained-world counterpart of
+//!   [`SceneEvaluator`](crate::SceneEvaluator). Evaluation is a pure query
+//!   (`eval_alpha`), so there is no stepping or seek bookkeeping to mirror —
+//!   `materialize_at → extract → collect` produces a
+//!   [`EvaluatedFrame`](crate::EvaluatedFrame) identical to the pure path.
+//!
+//! The render side is untouched: collect emits `((animation_id, part), CoreItem)`
+//! exactly like the pre-ECS path, so `RenderWorld` reconciliation keeps working.
+
+use std::collections::{HashMap, HashSet};
+
+use bevy_ecs::{component::Component, entity::Entity, world::World};
+
+use crate::{
+    Extract, SealedRanimScene,
+    animation::AnimationCell,
+    core_item::{AnyExtractCoreItem, CoreItem},
+    scene_evaluator::EvaluatedFrame,
+};
+
+/// A top-level item that can live in the `LogicWorld` as a typed component.
+///
+/// `LogicItem` = a Send+Sync bevy component that can also degrade to the
+/// closed [`CoreItem`] enum. Every item type participating in the world
+/// implements this **explicitly** (no blanket): that is what lets the
+/// compiler prove `Vec<T>` is *not* a `LogicItem`, so container outputs can
+/// take a separate materialization path without a coherence conflict.
+pub trait LogicItem: Component + AnyExtractCoreItem {}
+
+// Core render primitives (host-known, always available).
+impl LogicItem for crate::core_item::camera_frame::CameraFrame {}
+impl LogicItem for crate::core_item::mesh_item::MeshItem {}
+impl LogicItem for crate::core_item::vitem::VItem {}
+
+/// A homogeneous batch of items materialized as a single entity holding the
+/// whole vector (e.g. `vec![...].show()` or a group animation output).
+/// Extraction degrades every element.
+#[derive(Component, Debug, Clone, PartialEq)]
+pub struct Batch<T>(pub Vec<T>);
+
+impl<T: LogicItem + Clone> LogicItem for Batch<T> {}
+
+impl<T: Extract<Target = CoreItem>> Extract for Batch<T> {
+    type Target = CoreItem;
+
+    fn extract_into(&self, buf: &mut Vec<Self::Target>) {
+        self.0.extract_into(buf);
+    }
+}
+
+/// What an `Eval` leaf may output to be materialized into the `LogicWorld`.
+///
+/// - single items (`T: LogicItem`) upsert a typed component;
+/// - `Vec<T>` (group outputs) upsert a [`Batch<T>`] component holding the
+///   whole vector as one entity.
+pub trait MaterializeOut: AnyExtractCoreItem + Send + Sync + 'static {
+    /// Materialize this output at the given slot.
+    fn materialize(self, ctx: &mut MaterializeCtx, part: u32);
+}
+
+impl<T: LogicItem> MaterializeOut for T {
+    fn materialize(self, ctx: &mut MaterializeCtx, part: u32) {
+        upsert_item(ctx, part, self);
+    }
+}
+
+impl<T: LogicItem + Clone> MaterializeOut for Vec<T> {
+    fn materialize(self, ctx: &mut MaterializeCtx, part: u32) {
+        upsert_item(ctx, part, Batch(self));
+    }
+}
+
+/// Host-known identity component: which logical item this entity is.
+///
+/// The key is `(animation_id, part)`: `animation_id` is the index of the
+/// owning top-level cell, `part` is the stable output slot within it. This
+/// matches the identity the pure path used for `RenderFrame`, so the world
+/// output is frame-identical.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ItemIdentity {
+    /// Index of the owning top-level cell.
+    pub animation_id: u32,
+    /// Stable output slot within that cell.
+    pub part: u32,
+}
+
+/// Host-known draw order. ECS query order is not scene order; the collect
+/// phase sorts by this explicitly (D0002 discipline).
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SceneOrder {
+    /// Index of the owning top-level cell.
+    pub animation_id: u32,
+    /// Stable output slot within that cell.
+    pub part: u32,
+}
+
+/// Type-erased per-entity extractor, written by the typed materializer.
+///
+/// The driver calls this to degrade the item component to `CoreItem`s without
+/// naming its type. In-process this is a plain fn pointer; the dylib path
+/// (stage 3) uses the same shape through a global registry instead.
+#[derive(Component, Clone, Copy)]
+pub struct ItemExtractor(pub fn(Entity, &World, &mut Vec<CoreItem>));
+
+/// Per-entity extraction output. The `Vec` is retained across frames so its
+/// allocation is reused (stage-2 `Extracted<T>` will generalize this).
+#[derive(Component, Default)]
+pub struct ExtractedItems(pub Vec<CoreItem>);
+
+/// Build the type-erased extractor for `T` (monomorphized at the typed site).
+fn extractor_of<T: LogicItem>() -> fn(Entity, &World, &mut Vec<CoreItem>) {
+    |entity, world, out| {
+        if let Some(item) = world.entity(entity).get::<T>() {
+            item.extract_into(out);
+        }
+    }
+}
+
+/// Materialization context threaded down the cell tree.
+///
+/// This is the internal context of the materialize phase: `part` counts
+/// output slots within the current top-level cell; every leaf materialization
+/// occupies exactly one slot (multiple extracted `CoreItem`s within a slot
+/// are expanded at collect time).
+pub struct MaterializeCtx<'w> {
+    /// The world being materialized into.
+    pub world: &'w mut World,
+    /// Cross-frame identity index (`(animation_id, part)` → entity).
+    pub index: &'w mut HashMap<(u32, u32), Entity>,
+    /// Index of the owning top-level cell.
+    pub animation_id: u32,
+    /// Next output slot within the current cell.
+    pub part: u32,
+    /// Keys materialized this frame (drives despawn of stale entities).
+    pub seen: &'w mut HashSet<(u32, u32)>,
+}
+
+/// Upsert a typed item component at the given `part` slot of the current
+/// `animation_id`: create the entity on first appearance, replace the
+/// component afterwards, and record the key as seen this frame.
+///
+/// If the slot already exists but holds a *different* component type (e.g. a
+/// sequence switched to a child segment whose output type differs), the stale
+/// entity is despawned and respawned so its [`ItemExtractor`] always matches
+/// the component actually stored.
+pub(crate) fn upsert_item<T: LogicItem>(ctx: &mut MaterializeCtx, part: u32, value: T) {
+    let key = (ctx.animation_id, part);
+    let entity = match ctx.index.get(&key) {
+        Some(&entity) if ctx.world.entity(entity).contains::<T>() => {
+            ctx.world.entity_mut(entity).insert(value);
+            entity
+        }
+        existing => {
+            if let Some(&entity) = existing {
+                ctx.world.despawn(entity);
+            }
+            ctx.world
+                .spawn((
+                    ItemIdentity {
+                        animation_id: key.0,
+                        part: key.1,
+                    },
+                    SceneOrder {
+                        animation_id: key.0,
+                        part: key.1,
+                    },
+                    ItemExtractor(extractor_of::<T>()),
+                    ExtractedItems::default(),
+                    value,
+                ))
+                .id()
+        }
+    };
+    ctx.index.insert(key, entity);
+    ctx.seen.insert(key);
+}
+
+/// The M2 driving session: owns the retained `LogicWorld` and materializes
+/// the cell tree into it.
+///
+/// Evaluation is a pure query (`eval_alpha`), so — like
+/// [`SceneEvaluator`](crate::SceneEvaluator) — the session needs no stepping
+/// or seek bookkeeping: stateful segments manage direction internally, and
+/// `materialize_at` simply asks every active cell to upsert its typed output
+/// at the target time.
+pub struct ScenePlayer {
+    cells: Vec<AnimationCell>,
+    world: World,
+    /// `(animation_id, part)` → entity, the cross-frame identity index.
+    index: HashMap<(u32, u32), Entity>,
+    total_secs: f64,
+    clock: f64,
+}
+
+impl ScenePlayer {
+    /// Consume a sealed scene and create a driving session with a fresh
+    /// `LogicWorld`.
+    pub fn new(scene: SealedRanimScene) -> Self {
+        Self {
+            cells: scene.animations,
+            world: World::new(),
+            index: HashMap::new(),
+            total_secs: scene.total_secs,
+            clock: 0.0,
+        }
+    }
+
+    /// Total scene duration.
+    pub fn total_secs(&self) -> f64 {
+        self.total_secs
+    }
+
+    /// Last materialized target time.
+    pub fn clock(&self) -> f64 {
+        self.clock
+    }
+
+    /// Number of live item entities in the `LogicWorld`.
+    pub fn item_count(&self) -> usize {
+        self.index.len()
+    }
+
+    /// Materialize the scene at `render_secs` into the `LogicWorld`: every
+    /// active cell evaluates and upserts its typed item components by
+    /// identity; entities whose identity no longer appears are despawned
+    /// ("entity lifetime = producer lifetime").
+    pub fn materialize_at(&mut self, render_secs: f64) {
+        let mut seen = HashSet::new();
+        for (animation_id, cell) in self.cells.iter().enumerate() {
+            if !cell.active_at(render_secs) {
+                continue;
+            }
+            let mut ctx = MaterializeCtx {
+                world: &mut self.world,
+                index: &mut self.index,
+                animation_id: animation_id as u32,
+                part: 0,
+                seen: &mut seen,
+            };
+            cell.materialize_at(render_secs, &mut ctx);
+        }
+        let stale: Vec<(u32, u32)> = self
+            .index
+            .keys()
+            .filter(|key| !seen.contains(key))
+            .copied()
+            .collect();
+        for key in stale {
+            if let Some(entity) = self.index.remove(&key) {
+                self.world.despawn(entity);
+            }
+        }
+        self.clock = render_secs;
+    }
+
+    /// Extract every live item to `CoreItem`s via its per-entity extractor.
+    pub fn extract(&mut self) {
+        let entities: Vec<Entity> = self
+            .world
+            .iter_entities()
+            .filter(|eref| eref.get::<ItemExtractor>().is_some())
+            .map(|eref| eref.id())
+            .collect();
+        for entity in entities {
+            let extractor = self.world.entity(entity).get::<ItemExtractor>().unwrap().0;
+            let mut buf = Vec::new();
+            extractor(entity, &self.world, &mut buf);
+            if let Some(mut extracted) = self.world.entity_mut(entity).get_mut::<ExtractedItems>() {
+                extracted.0 = buf;
+            }
+        }
+    }
+
+    /// Collect the extracted items into an [`EvaluatedFrame`](crate::EvaluatedFrame)
+    /// sorted by scene order. The frame identity `(animation_id, part)` uses
+    /// the same flattened part indexing as the pure path, so output is
+    /// frame-identical and the renderer needs no changes.
+    pub fn collect(&self, out: &mut EvaluatedFrame) {
+        let mut ordered: Vec<(SceneOrder, Entity)> = Vec::new();
+        for eref in self.world.iter_entities() {
+            let Some(order) = eref.get::<SceneOrder>() else {
+                continue;
+            };
+            if eref.get::<ItemIdentity>().is_none() {
+                continue;
+            }
+            ordered.push((*order, eref.id()));
+        }
+        ordered.sort_by_key(|(order, _)| *order);
+
+        let mut current_animation: Option<u32> = None;
+        let mut flat_part = 0usize;
+        for (order, entity) in ordered {
+            if current_animation != Some(order.animation_id) {
+                current_animation = Some(order.animation_id);
+                flat_part = 0;
+            }
+            let Some(extracted) = self.world.entity(entity).get::<ExtractedItems>() else {
+                continue;
+            };
+            for core in &extracted.0 {
+                out.push(((order.animation_id as usize, flat_part), core.clone()));
+                flat_part += 1;
+            }
+        }
+    }
+
+    /// One frame: materialize at `render_secs`, then extract → collect into
+    /// `out`. Convenience wrapper mirroring the pure path's
+    /// [`SceneEvaluator::sample_at`](crate::SceneEvaluator::sample_at).
+    pub fn frame(&mut self, render_secs: f64, out: &mut EvaluatedFrame) {
+        self.materialize_at(render_secs);
+        self.extract();
+        self.collect(out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        RanimScene, SealedRanimScene, seq,
+        animation::{AnimationExt, StaticAnim, eval::Eval, eval::iterative::Iterative},
+        core_item::{camera_frame::CameraFrame, mesh_item::MeshItem, vitem::VItem},
+    };
+
+    /// Pure evaluator: a vitem sliding along X with `alpha`.
+    struct MoveX;
+    impl Eval for MoveX {
+        type Output = VItem;
+
+        fn eval_alpha(&self, alpha: f64) -> Self::Output {
+            let mut v = VItem::default();
+            v.points[0].x = alpha as f32;
+            v
+        }
+    }
+
+    /// Iterative segment: x accumulates `rate * delta_alpha` per step.
+    fn drift(rate: f32) -> impl crate::animation::Placeable {
+        Iterative::from_fn(
+            VItem::default(),
+            move |state: &mut VItem, _alpha: f64, delta_alpha: f64| {
+                state.points[0].x += rate * delta_alpha as f32;
+            },
+        )
+        .with_duration(1.0)
+    }
+
+    fn build() -> SealedRanimScene {
+        let mut scene = RanimScene::new();
+        scene.play(CameraFrame::default().show().with_duration(3.0));
+        scene.play(MoveX.with_duration(1.0));
+        scene.play(seq![drift(1.0), drift(2.0)]);
+        scene.seal()
+    }
+
+    /// The world path must produce frame-identical output to the pure path.
+    #[test]
+    fn player_output_matches_evaluator() {
+        let mut ev = build().into_evaluator(120.0);
+        let mut pl = ScenePlayer::new(build());
+
+        for t in [0.0, 0.3, 0.7, 1.0, 1.2, 1.8, 2.5, 3.0] {
+            let mut frame_ev = Vec::new();
+            ev.sample_at(t, &mut frame_ev);
+
+            let mut frame_pl = Vec::new();
+            pl.frame(t, &mut frame_pl);
+
+            assert_eq!(frame_pl, frame_ev, "frame mismatch at t = {t}");
+        }
+    }
+
+    /// A backward jump forces iterative leaves to reset+replay internally;
+    /// sampling the same target again must match the forward result.
+    #[test]
+    fn player_seek_matches_forward() {
+        let mut pl = ScenePlayer::new(build());
+        let mut forward = Vec::new();
+        pl.frame(1.5, &mut forward);
+
+        pl.frame(0.4, &mut Vec::new()); // backward jump
+        let mut replayed = Vec::new();
+        pl.frame(1.5, &mut replayed);
+
+        assert_eq!(replayed, forward, "seek replay must equal forward sampling");
+    }
+
+    /// Entities are retained across frames and updated by identity, not
+    /// re-spawned; stale entities are despawned when their producer leaves.
+    #[test]
+    fn entities_are_retained_and_lifetime_follows_producer() {
+        let mut pl = ScenePlayer::new(build());
+
+        // t=0.3: camera + movex + seq[first drift] active → 3 entities.
+        pl.frame(0.3, &mut Vec::new());
+        assert_eq!(pl.item_count(), 3);
+
+        // Same time again: identity upsert, no new entities.
+        pl.frame(0.3, &mut Vec::new());
+        assert_eq!(pl.item_count(), 3);
+
+        // t=1.5: movex ended (despawned), seq moved to second drift (same
+        // entity slot, upserted) → camera + seq = 2.
+        pl.frame(1.5, &mut Vec::new());
+        assert_eq!(pl.item_count(), 2);
+
+        // t=2.5: drift seq ended → 1 entity (camera only).
+        pl.frame(2.5, &mut Vec::new());
+        assert_eq!(pl.item_count(), 1);
+
+        // Backwards jump: entities whose producers are active again respawn.
+        pl.materialize_at(0.3);
+        assert_eq!(pl.item_count(), 3);
+    }
+
+    /// A slot reused across sequence segments with different output types
+    /// respawns its entity so the extractor matches the stored component.
+    #[test]
+    fn slot_type_change_respawns_entity() {
+        struct ShowMesh;
+        impl Eval for ShowMesh {
+            type Output = MeshItem;
+
+            fn eval_alpha(&self, _alpha: f64) -> Self::Output {
+                MeshItem::default()
+            }
+        }
+
+        let mut scene = RanimScene::new();
+        scene.play(seq![MoveX.with_duration(1.0), ShowMesh.with_duration(1.0)]);
+        let mut pl = ScenePlayer::new(scene.seal());
+
+        let mut frame = Vec::new();
+        pl.frame(0.5, &mut frame);
+        assert_eq!(frame.len(), 1);
+        assert!(matches!(frame[0].1, CoreItem::VItem(_)));
+
+        let mut frame = Vec::new();
+        pl.frame(1.5, &mut frame);
+        assert_eq!(frame.len(), 1);
+        assert!(matches!(frame[0].1, CoreItem::MeshItem(_)));
+    }
+}

--- a/packages/ranim-core/src/scene_evaluator.rs
+++ b/packages/ranim-core/src/scene_evaluator.rs
@@ -16,6 +16,40 @@ use crate::{
 /// A reusable frame-local output buffer of `((animation_id, part), CoreItem)`.
 pub type EvaluatedFrame = Vec<((usize, usize), CoreItem)>;
 
+/// A scene driving session: the common interface of the pure evaluator
+/// ([`SceneEvaluator`]) and the retained-world player
+/// ([`ScenePlayer`](crate::ScenePlayer)).
+///
+/// Evaluation is a pure query (`eval_alpha`), so a session needs no stepping
+/// or seek bookkeeping: [`sample_at`](SceneSession::sample_at) is the only
+/// interaction, and direction management is internal to each stateful node.
+/// The two implementations produce identical frames for the same target,
+/// so consumers can treat them interchangeably.
+pub trait SceneSession {
+    /// Consume a sealed scene and create a driving session.
+    ///
+    /// `logic_fps` is retained only for call-site compatibility; it no longer
+    /// drives stepping (each iterative segment owns its `sim_step`).
+    fn from_sealed(scene: SealedRanimScene, logic_fps: f64) -> Self;
+
+    /// Total scene duration.
+    fn total_secs(&self) -> f64;
+
+    /// Last sampled target (the `clock` reading for preview tooling).
+    fn clock(&self) -> f64;
+
+    /// Scene time marks.
+    fn time_marks(&self) -> &[(f64, TimeMark)];
+
+    /// Hierarchical runtime animation information for preview tooling.
+    fn animation_infos(&self) -> Vec<AnimationInfo>;
+
+    /// Sample the scene at `render_secs` into `out` — the ONLY session
+    /// interaction. `out` is appended to; clearing it between frames is the
+    /// caller's responsibility.
+    fn sample_at(&mut self, render_secs: f64, out: &mut EvaluatedFrame);
+}
+
 /// Lightweight scene evaluation session.
 pub struct SceneEvaluator {
     cells: Vec<AnimationCell>,
@@ -80,6 +114,32 @@ impl SceneEvaluator {
             }
         }
         self.clock = render_secs;
+    }
+}
+
+impl SceneSession for SceneEvaluator {
+    fn from_sealed(scene: SealedRanimScene, logic_fps: f64) -> Self {
+        Self::new(scene, logic_fps)
+    }
+
+    fn total_secs(&self) -> f64 {
+        self.total_secs()
+    }
+
+    fn clock(&self) -> f64 {
+        self.clock()
+    }
+
+    fn time_marks(&self) -> &[(f64, TimeMark)] {
+        self.time_marks()
+    }
+
+    fn animation_infos(&self) -> Vec<AnimationInfo> {
+        self.animation_infos()
+    }
+
+    fn sample_at(&mut self, render_secs: f64, out: &mut EvaluatedFrame) {
+        self.sample_at(render_secs, out);
     }
 }
 

--- a/packages/ranim-core/src/scene_evaluator.rs
+++ b/packages/ranim-core/src/scene_evaluator.rs
@@ -27,10 +27,7 @@ pub type EvaluatedFrame = Vec<((usize, usize), CoreItem)>;
 /// so consumers can treat them interchangeably.
 pub trait SceneSession {
     /// Consume a sealed scene and create a driving session.
-    ///
-    /// `logic_fps` is retained only for call-site compatibility; it no longer
-    /// drives stepping (each iterative segment owns its `sim_step`).
-    fn from_sealed(scene: SealedRanimScene, logic_fps: f64) -> Self;
+    fn from_sealed(scene: SealedRanimScene) -> Self;
 
     /// Total scene duration.
     fn total_secs(&self) -> f64;
@@ -60,11 +57,7 @@ pub struct SceneEvaluator {
 
 impl SceneEvaluator {
     /// Consume a sealed scene and create a driving session.
-    ///
-    /// `logic_fps` is retained only for call-site compatibility; it no longer
-    /// drives stepping (each iterative segment owns its `sim_step`).
-    #[allow(unused_variables)]
-    pub fn new(scene: SealedRanimScene, logic_fps: f64) -> Self {
+    pub fn new(scene: SealedRanimScene) -> Self {
         Self {
             cells: scene.animations,
             total_secs: scene.total_secs,
@@ -118,8 +111,8 @@ impl SceneEvaluator {
 }
 
 impl SceneSession for SceneEvaluator {
-    fn from_sealed(scene: SealedRanimScene, logic_fps: f64) -> Self {
-        Self::new(scene, logic_fps)
+    fn from_sealed(scene: SealedRanimScene) -> Self {
+        Self::new(scene)
     }
 
     fn total_secs(&self) -> f64 {
@@ -223,7 +216,7 @@ mod tests {
         scene.play(ProgressX.with_duration(2.0));
         let sealed = scene.seal();
 
-        let mut ev = SceneEvaluator::new(sealed, 120.0);
+        let mut ev = SceneEvaluator::new(sealed);
         for sec in [0.0, 0.25, 0.5, 1.0, 1.5, 2.0] {
             let mut frame = EvaluatedFrame::new();
             ev.sample_at(sec, &mut frame);
@@ -237,7 +230,7 @@ mod tests {
     fn iterative_segment_steps_along_logic_grid() {
         let mut scene = RanimScene::new();
         scene.play(cv(1.0, 2.0).with_duration(2.0).at(0.0));
-        let mut ev = SceneEvaluator::new(scene.seal(), 120.0);
+        let mut ev = SceneEvaluator::new(scene.seal());
 
         for sec in [0.0, 0.5, 1.0, 1.5, 2.0] {
             let mut frame = EvaluatedFrame::new();
@@ -255,7 +248,7 @@ mod tests {
         }
 
         let run = |backward: bool| {
-            let mut ev = SceneEvaluator::new(build_scene(), 120.0);
+            let mut ev = SceneEvaluator::new(build_scene());
             let mut trace = Vec::new();
             for sec in [0.3, 0.7, 1.1, 1.9, 2.6] {
                 if backward {
@@ -283,7 +276,7 @@ mod tests {
             .at(0.0),
         );
 
-        let mut ev = SceneEvaluator::new(scene.seal(), 120.0);
+        let mut ev = SceneEvaluator::new(scene.seal());
         let mut frame = EvaluatedFrame::new();
         ev.sample_at(1.5, &mut frame);
         assert_eq!(xs_of(&frame), vec![0.5]);
@@ -308,7 +301,7 @@ mod tests {
         }
 
         let run = |backward: bool| {
-            let mut ev = SceneEvaluator::new(build_scene(), 120.0);
+            let mut ev = SceneEvaluator::new(build_scene());
             let mut trace = Vec::new();
             for sec in [0.3, 0.7, 1.1, 1.5, 1.9] {
                 if backward {

--- a/packages/ranim-examples/Cargo.toml
+++ b/packages/ranim-examples/Cargo.toml
@@ -15,6 +15,7 @@ ranim = { workspace = true, features = ["preview", "anims", "items", "typst"] }
 ranim-core.workspace = true
 ranim-items.workspace = true
 ranim-anims.workspace = true
+bevy_ecs.workspace = true
 itertools.workspace = true
 rand = "0.10.2"
 rand_chacha = "0.10.0"

--- a/packages/ranim-items/Cargo.toml
+++ b/packages/ranim-items/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 ranim-core.workspace = true
+bevy_ecs.workspace = true
 ranim-macros.workspace = true
 tracing.workspace = true
 itertools.workspace = true

--- a/packages/ranim-items/src/debug.rs
+++ b/packages/ranim-items/src/debug.rs
@@ -14,7 +14,7 @@ use ranim_core::{
 use crate::vitem::geometry::Rectangle;
 
 /// Wrapper that visualizes the AABB of the inner item as a wireframe rectangle.
-#[derive(Clone)]
+#[derive(bevy_ecs::component::Component, Clone)]
 pub struct VisualizeAabbItem<T: Aabb>(pub T);
 
 impl<T: Aabb> Deref for VisualizeAabbItem<T> {

--- a/packages/ranim-items/src/lib.rs
+++ b/packages/ranim-items/src/lib.rs
@@ -8,5 +8,7 @@
 )]
 
 pub mod debug;
+/// Explicit `LogicItem` impls for built-in item types.
+pub mod logic_impls;
 pub mod mesh;
 pub mod vitem;

--- a/packages/ranim-items/src/logic_impls.rs
+++ b/packages/ranim-items/src/logic_impls.rs
@@ -1,0 +1,45 @@
+//! Explicit `LogicItem` impls for the built-in item types.
+//!
+//! `LogicItem` deliberately has **no blanket impl** — explicit impls are what
+//! let the compiler prove containers like `Vec<T>` are not `LogicItem`, so
+//! group outputs can take a separate materialization path (see
+//! `ranim_core::logic::MaterializeOut`). New built-in item types must add
+//! their impl here; dylib item types never do (they register their own
+//! materializers, E4 pattern).
+
+use ranim_core::logic::LogicItem;
+
+use crate::debug::VisualizeAabbItem;
+use crate::mesh::{MeshItem, Sphere, Surface};
+use crate::vitem::geometry::{
+    Arc, ArcBetweenPoints, Circle, Ellipse, EllipticArc, Line, Parallelogram, Polygon, Rectangle,
+    RegularPolygon, Square,
+};
+use crate::vitem::svg::SvgItem;
+use crate::vitem::VItem;
+#[cfg(feature = "typst")]
+use crate::vitem::{text::TextItem, typst::TypstText};
+
+impl LogicItem for MeshItem {}
+impl LogicItem for Sphere {}
+impl LogicItem for Surface {}
+impl LogicItem for VItem {}
+impl LogicItem for Arc {}
+impl LogicItem for ArcBetweenPoints {}
+impl LogicItem for Circle {}
+impl LogicItem for Ellipse {}
+impl LogicItem for EllipticArc {}
+impl LogicItem for Line {}
+impl LogicItem for Parallelogram {}
+impl LogicItem for Polygon {}
+impl LogicItem for Rectangle {}
+impl LogicItem for RegularPolygon {}
+impl LogicItem for Square {}
+impl LogicItem for SvgItem {}
+
+impl<T: LogicItem + ranim_core::anchor::Aabb + Clone> LogicItem for VisualizeAabbItem<T> {}
+
+#[cfg(feature = "typst")]
+impl LogicItem for TextItem {}
+#[cfg(feature = "typst")]
+impl LogicItem for TypstText {}

--- a/packages/ranim-items/src/mesh/mod.rs
+++ b/packages/ranim-items/src/mesh/mod.rs
@@ -24,7 +24,7 @@ pub use surface::*;
 /// This struct uses [`PointVec`] to wrap vertex data, enabling proper alignment
 /// and interpolation for animations. When extracted, it converts to the low-level
 /// [`ranim_core::core_item::mesh_item::MeshItem`] for rendering.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(bevy_ecs::component::Component, Debug, Clone, PartialEq)]
 pub struct MeshItem {
     /// The vertices of the mesh
     pub points: PointVec<DVec3>,

--- a/packages/ranim-items/src/mesh/sphere.rs
+++ b/packages/ranim-items/src/mesh/sphere.rs
@@ -22,7 +22,7 @@ use super::Surface;
 /// - `x = r * cos(u) * sin(v)`
 /// - `y = r * sin(u) * sin(v)`
 /// - `z = r * (-cos(v))`
-#[derive(Debug, Clone, PartialEq)]
+#[derive(bevy_ecs::component::Component, Debug, Clone, PartialEq)]
 pub struct Sphere {
     /// Center of the sphere.
     pub center: DVec3,

--- a/packages/ranim-items/src/mesh/surface.rs
+++ b/packages/ranim-items/src/mesh/surface.rs
@@ -49,7 +49,7 @@ fn colorscale_lookup(colorscale: &[(AlphaColor<Srgb>, f64)], value: f64) -> Alph
 ///
 /// By default, vertex normals are all-zero, which causes flat shading.
 /// To enable smooth shading, call [`Self::with_smooth_normals`] or [`Self::update_smooth_normals`] to update the normals.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(bevy_ecs::component::Component, Debug, Clone, PartialEq)]
 pub struct Surface {
     /// Vertices — `nu * nv` points in row-major order.
     pub vertices: Vec<DVec3>,

--- a/packages/ranim-items/src/vitem/arrow.rs
+++ b/packages/ranim-items/src/vitem/arrow.rs
@@ -22,7 +22,7 @@ use super::{line::Line, Polygon, VItem};
 ///           /   \
 /// 0.1 * -X +-----+ 0.1 * X
 /// ```
-#[derive(
+#[derive(bevy_ecs::component::Component, 
     Clone,
     Interpolatable,
     Alignable,

--- a/packages/ranim-items/src/vitem/geometry/arc.rs
+++ b/packages/ranim-items/src/vitem/geometry/arc.rs
@@ -16,7 +16,7 @@ use ranim_core::anchor::AabbPoint;
 
 // MARK: ### Arc ###
 /// An arc
-#[derive(Clone, Debug, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Clone, Debug, ranim_macros::Interpolatable)]
 pub struct Arc {
     /// Axes
     pub axes: (DVec3, DVec3),
@@ -143,7 +143,7 @@ impl Extract for Arc {
 
 // MARK: ### ArcBetweenPoints ###
 /// An arc between points
-#[derive(Clone, Debug, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Clone, Debug, ranim_macros::Interpolatable)]
 pub struct ArcBetweenPoints {
     /// Axes
     pub axes: (DVec3, DVec3),

--- a/packages/ranim-items/src/vitem/geometry/circle.rs
+++ b/packages/ranim-items/src/vitem/geometry/circle.rs
@@ -21,7 +21,7 @@ use super::Arc;
 
 // MARK: ### Circle ###
 /// An circle
-#[derive(Clone, Debug, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Clone, Debug, ranim_macros::Interpolatable)]
 pub struct Circle {
     /// Axes
     pub axes: (DVec3, DVec3),

--- a/packages/ranim-items/src/vitem/geometry/ellipse.rs
+++ b/packages/ranim-items/src/vitem/geometry/ellipse.rs
@@ -14,7 +14,7 @@ use crate::vitem::{
 };
 
 /// An ellipse.
-#[derive(Clone, Debug, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Clone, Debug, ranim_macros::Interpolatable)]
 pub struct Ellipse {
     /// Axes
     pub axes: (DVec3, DVec3),

--- a/packages/ranim-items/src/vitem/geometry/elliptic_arc.rs
+++ b/packages/ranim-items/src/vitem/geometry/elliptic_arc.rs
@@ -17,7 +17,7 @@ use crate::vitem::{
 };
 
 /// An elliptic arc.
-#[derive(Debug, Clone, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Debug, Clone, ranim_macros::Interpolatable)]
 pub struct EllipticArc {
     /// Axes
     pub axes: (DVec3, DVec3),

--- a/packages/ranim-items/src/vitem/geometry/line.rs
+++ b/packages/ranim-items/src/vitem/geometry/line.rs
@@ -13,7 +13,7 @@ use ranim_macros::Interpolatable;
 use crate::vitem::VItem;
 
 /// A line segment.
-#[derive(Debug, Clone, Interpolatable)]
+#[derive(bevy_ecs::component::Component, Debug, Clone, Interpolatable)]
 pub struct Line {
     /// The start and end points of the line.
     pub points: [DVec3; 2],

--- a/packages/ranim-items/src/vitem/geometry/parallelogram.rs
+++ b/packages/ranim-items/src/vitem/geometry/parallelogram.rs
@@ -16,7 +16,7 @@ use crate::vitem::{
 };
 
 /// A parallelogram.
-#[derive(Debug, Clone, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Debug, Clone, ranim_macros::Interpolatable)]
 pub struct Parallelogram {
     /// Origin of the paralleogram
     pub origin: DVec3,

--- a/packages/ranim-items/src/vitem/geometry/polygon.rs
+++ b/packages/ranim-items/src/vitem/geometry/polygon.rs
@@ -17,7 +17,7 @@ use ranim_core::traits::{Alignable, FillColor, Opacity, StrokeColor, StrokeWidth
 
 // MARK: ### Square ###
 /// A Square
-#[derive(Clone, Debug, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Clone, Debug, ranim_macros::Interpolatable)]
 pub struct Square {
     /// Axes
     pub axes: (DVec3, DVec3),
@@ -201,7 +201,7 @@ impl From<Square> for VItem {
 
 // MARK: ### Rectangle ###
 /// Rectangle
-#[derive(Clone, Debug, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Clone, Debug, ranim_macros::Interpolatable)]
 pub struct Rectangle {
     /// Axes info
     pub axes: (DVec3, DVec3),
@@ -362,7 +362,7 @@ impl Extract for Rectangle {
 
 // MARK: ### Polygon ###
 /// A Polygon with uniform stroke and fill
-#[derive(Clone, Debug, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Clone, Debug, ranim_macros::Interpolatable)]
 pub struct Polygon {
     /// Axes info
     pub axes: (DVec3, DVec3),
@@ -519,7 +519,7 @@ impl Extract for Polygon {
     }
 }
 
-#[derive(Debug, Clone, ranim_macros::Interpolatable)]
+#[derive(bevy_ecs::component::Component, Debug, Clone, ranim_macros::Interpolatable)]
 /// A regular polygon.
 pub struct RegularPolygon {
     /// Local coordinate system

--- a/packages/ranim-items/src/vitem/mod.rs
+++ b/packages/ranim-items/src/vitem/mod.rs
@@ -53,7 +53,7 @@ use ranim_core::{
 ///     dvec3(0.5, 1.0, 0.0),
 /// ]);
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(bevy_ecs::component::Component, Debug, Clone, PartialEq)]
 pub struct VItem {
     /// The normal vector of the projection target plane.
     /// If `None`, the normal will be derived from the points at render time.

--- a/packages/ranim-items/src/vitem/svg.rs
+++ b/packages/ranim-items/src/vitem/svg.rs
@@ -16,7 +16,7 @@ use super::VItem;
 /// An Svg Item
 ///
 /// Its inner is a `Vec<VItem>`
-#[derive(
+#[derive(bevy_ecs::component::Component, 
     Clone, ranim_macros::ShiftTransform, ranim_macros::RotateTransform, ranim_macros::ScaleTransform,
 )]
 pub struct SvgItem(Vec<VItem>);

--- a/packages/ranim-items/src/vitem/text.rs
+++ b/packages/ranim-items/src/vitem/text.rs
@@ -1,6 +1,6 @@
 use std::{
-    cell::{Cell, Ref, RefCell},
     collections::HashMap,
+    sync::Mutex,
 };
 
 use ranim_core::{
@@ -73,7 +73,7 @@ impl Default for TextFont {
 }
 
 /// Simple single-line text item
-#[derive(Clone, Debug)]
+#[derive(bevy_ecs::component::Component, Debug)]
 pub struct TextItem {
     /// Origin
     origin: DVec3,
@@ -89,10 +89,27 @@ pub struct TextItem {
     stroke_rgbas: AlphaColor<Srgb>,
     /// Stroke width
     stroke_width: f32,
-    /// Cached items
-    items: RefCell<Option<Vec<VItem>>>,
+    /// Cached items (Mutex for Send+Sync; the cache itself moves to
+    /// `Extracted<T>` in M2 stage 2).
+    items: Mutex<Option<Vec<VItem>>>,
     /// cached text inline size
-    inline_length_em: Cell<Option<f64>>,
+    inline_length_em: Mutex<Option<f64>>,
+}
+
+impl Clone for TextItem {
+    fn clone(&self) -> Self {
+        Self {
+            origin: self.origin,
+            basis: self.basis,
+            text: self.text.clone(),
+            font: self.font.clone(),
+            fill_rgbas: self.fill_rgbas,
+            stroke_rgbas: self.stroke_rgbas,
+            stroke_width: self.stroke_width,
+            items: Mutex::new(self.items.lock().unwrap().clone()),
+            inline_length_em: Mutex::new(*self.inline_length_em.lock().unwrap()),
+        }
+    }
 }
 
 impl Locate<TextItem> for Origin {
@@ -112,15 +129,15 @@ impl TextItem {
             fill_rgbas: AlphaColor::WHITE,
             stroke_rgbas: AlphaColor::WHITE,
             stroke_width: 0.0,
-            items: RefCell::default(),
-            inline_length_em: Cell::default(),
+            items: Mutex::default(),
+            inline_length_em: Mutex::default(),
         }
     }
 
     /// Set font
     pub fn with_font(mut self, font: TextFont) -> Self {
         self.font = font;
-        self.items.take();
+        *self.items.lock().unwrap() = None;
         self
     }
 
@@ -141,8 +158,8 @@ impl TextItem {
 
     /// Get inline length in em units
     pub fn inline_length_em(&self) -> f64 {
-        let _ = self.items(); // ensure items are generated
-        self.inline_length_em.get().unwrap()
+        drop(self.items()); // ensure items are generated
+        self.inline_length_em.lock().unwrap().unwrap()
     }
 
     /// Returns the text outline box starting from baseline origin to the width of last character and em height.
@@ -231,7 +248,7 @@ impl TextItem {
         } = self;
         let [min, max] = baseline_em_box;
         let h = max.y - min.y;
-        self.inline_length_em.set(Some((max.x - min.x) / h));
+        *self.inline_length_em.lock().unwrap() = Some((max.x - min.x) / h);
         let mat = DAffine3::from_mat3_translation(DMat3::from_cols(u, v, DVec3::ZERO), origin);
         texts.with(|x| {
             x.shift(-min)
@@ -244,16 +261,15 @@ impl TextItem {
         })
     }
 
-    fn items(&self) -> Ref<'_, Vec<VItem>> {
-        if self.items.borrow().is_none() {
-            let items = self.generate_items();
-            self.items.replace(Some(items));
+    fn items(&self) -> std::sync::MutexGuard<'_, Option<Vec<VItem>>> {
+        if self.items.lock().unwrap().is_none() {
+            *self.items.lock().unwrap() = Some(self.generate_items());
         }
-        Ref::map(self.items.borrow(), |v| v.as_ref().unwrap())
+        self.items.lock().unwrap()
     }
 
     fn transform_items(&self, transformation: impl FnOnce(&mut Vec<VItem>)) {
-        if let Some(v) = self.items.borrow_mut().as_mut() {
+        if let Some(v) = self.items.lock().unwrap().as_mut() {
             transformation(v);
         }
     }
@@ -261,7 +277,7 @@ impl TextItem {
 
 impl Aabb for TextItem {
     fn aabb(&self) -> [DVec3; 2] {
-        self.items().aabb()
+        self.items().as_ref().unwrap().aabb()
     }
 }
 
@@ -331,7 +347,7 @@ impl StrokeColor for TextItem {
 
 impl From<TextItem> for Vec<VItem> {
     fn from(item: TextItem) -> Self {
-        item.items().clone()
+        item.items().as_ref().unwrap().clone()
     }
 }
 
@@ -339,7 +355,7 @@ impl Extract for TextItem {
     type Target = CoreItem;
 
     fn extract_into(&self, buf: &mut Vec<Self::Target>) {
-        self.items().extract_into(buf);
+        self.items().as_ref().unwrap().extract_into(buf);
     }
 }
 

--- a/packages/ranim-items/src/vitem/typst.rs
+++ b/packages/ranim-items/src/vitem/typst.rs
@@ -245,7 +245,7 @@ impl World for TypstWorldWithSource<'_> {
 ///
 /// Note that the methods this item provides assumes that the typst string
 /// you provide only produces text output, otherwise undefined behaviours may happens.
-#[derive(Clone)]
+#[derive(bevy_ecs::component::Component, Clone)]
 pub struct TypstText {
     chars: String,
     vitems: Vec<VItem>,

--- a/packages/ranim-render/src/lib.rs
+++ b/packages/ranim-render/src/lib.rs
@@ -151,6 +151,23 @@ impl Renderer {
         self.world.run_schedule(RenderPrepare);
         self.world.run_schedule(RenderGraph);
     }
+
+    /// Reconcile directly from a `LogicWorld` and render one frame (M2 direct
+    /// extraction): same render schedules as [`render_frame`](Self::render_frame),
+    /// but the extracted items move out of the logic world instead of being
+    /// cloned through a transport frame.
+    pub fn render_logic_frame(
+        &mut self,
+        render_textures: &mut RenderTextures,
+        clear_color: wgpu::Color,
+        logic: &mut bevy_ecs::world::World,
+    ) {
+        crate::world::reconcile_logic(&mut self.world, logic);
+        self.world
+            .insert_resource(FrameTarget::new(render_textures, clear_color));
+        self.world.run_schedule(RenderPrepare);
+        self.world.run_schedule(RenderGraph);
+    }
 }
 
 #[allow(unused)]

--- a/packages/ranim-render/src/world.rs
+++ b/packages/ranim-render/src/world.rs
@@ -71,58 +71,29 @@ pub(crate) struct SceneOrder(pub usize);
 #[derive(Resource, Default)]
 pub(crate) struct CoreItemEntities(CoreItemIdMap<Entity>);
 
-pub(crate) fn reconcile(world: &mut World, frame: &RenderFrame) {
-    let mut seen = CoreItemIdSet::with_capacity_and_hasher(
-        frame.items.len(),
-        CoreItemIdBuildHasher::default(),
-    );
-
-    for (order, (id, item)) in frame.iter().enumerate() {
-        assert!(seen.insert(*id), "duplicate CoreItem id {id:?}");
-
-        let (entity, is_new) = if let Some(entity) = world.resource::<CoreItemEntities>().0.get(id)
-        {
-            (*entity, false)
-        } else {
-            let entity = world.spawn((CoreItemIdentity(*id), SceneOrder(order))).id();
-            world
-                .resource_mut::<CoreItemEntities>()
-                .0
-                .insert(*id, entity);
-            (entity, true)
-        };
-
+/// Get or spawn the render entity for `id`, refreshing its draw order.
+fn upsert_entity(world: &mut World, id: CoreItemId, order: usize) -> (Entity, bool) {
+    if let Some(entity) = world.resource::<CoreItemEntities>().0.get(&id) {
+        let entity = *entity;
         replace_component(world, entity, &SceneOrder(order));
-        match item {
-            CoreItem::CameraFrame(item) => {
-                let changes_kind = world.get::<CameraFrame>(entity).is_none();
-                replace_component(world, entity, item);
-                if !is_new && changes_kind {
-                    world.entity_mut(entity).remove::<(VItem, MeshItem)>();
-                }
-            }
-            CoreItem::VItem(item) => {
-                let changes_kind = world.get::<VItem>(entity).is_none();
-                replace_component(world, entity, item);
-                if !is_new && changes_kind {
-                    world.entity_mut(entity).remove::<(CameraFrame, MeshItem)>();
-                }
-            }
-            CoreItem::MeshItem(item) => {
-                let changes_kind = world.get::<MeshItem>(entity).is_none();
-                replace_component(world, entity, item);
-                if !is_new && changes_kind {
-                    world.entity_mut(entity).remove::<(CameraFrame, VItem)>();
-                }
-            }
-        }
+        (entity, false)
+    } else {
+        let entity = world.spawn((CoreItemIdentity(id), SceneOrder(order))).id();
+        world
+            .resource_mut::<CoreItemEntities>()
+            .0
+            .insert(id, entity);
+        (entity, true)
     }
+}
 
+/// Despawn render entities whose identity did not appear this frame.
+fn despawn_stale(world: &mut World, seen: &CoreItemIdSet) {
     let stale = world
         .resource::<CoreItemEntities>()
         .0
         .keys()
-        .filter(|id| !seen.contains(id))
+        .filter(|id| !seen.contains(*id))
         .copied()
         .collect::<Vec<_>>();
     for id in stale {
@@ -133,6 +104,106 @@ pub(crate) fn reconcile(world: &mut World, frame: &RenderFrame) {
             .unwrap();
         world.despawn(entity);
     }
+}
+
+/// Replace a component with an owned value only when it actually changed
+/// (preserving change ticks), moving instead of cloning.
+fn replace_component_owned<T>(world: &mut World, entity: Entity, value: T)
+where
+    T: Component + PartialEq,
+{
+    if world.get::<T>(entity) != Some(&value) {
+        world.entity_mut(entity).insert(value);
+    }
+}
+
+/// Upsert one core item at `id`, replacing the previous item kind if needed.
+fn upsert_core_item(world: &mut World, id: CoreItemId, order: usize, item: CoreItem) {
+    let (entity, is_new) = upsert_entity(world, id, order);
+    match item {
+        CoreItem::CameraFrame(item) => {
+            let changes_kind = world.get::<CameraFrame>(entity).is_none();
+            replace_component_owned(world, entity, item);
+            if !is_new && changes_kind {
+                world.entity_mut(entity).remove::<(VItem, MeshItem)>();
+            }
+        }
+        CoreItem::VItem(item) => {
+            let changes_kind = world.get::<VItem>(entity).is_none();
+            replace_component_owned(world, entity, item);
+            if !is_new && changes_kind {
+                world.entity_mut(entity).remove::<(CameraFrame, MeshItem)>();
+            }
+        }
+        CoreItem::MeshItem(item) => {
+            let changes_kind = world.get::<MeshItem>(entity).is_none();
+            replace_component_owned(world, entity, item);
+            if !is_new && changes_kind {
+                world.entity_mut(entity).remove::<(CameraFrame, VItem)>();
+            }
+        }
+    }
+}
+
+/// Reconcile the render world from a transport frame.
+pub fn reconcile(world: &mut World, frame: &RenderFrame) {
+    world.init_resource::<CoreItemEntities>();
+    let mut seen = CoreItemIdSet::with_capacity_and_hasher(
+        frame.items.len(),
+        CoreItemIdBuildHasher::default(),
+    );
+
+    for (order, (id, item)) in frame.iter().enumerate() {
+        assert!(seen.insert(*id), "duplicate CoreItem id {id:?}");
+        upsert_core_item(world, *id, order, item.clone());
+    }
+
+    despawn_stale(world, &seen);
+}
+
+/// Reconcile the render world directly from a `LogicWorld` (M2 direct
+/// extraction): drains each logic entity's
+/// [`ExtractedItems`](ranim_core::logic::ExtractedItems) and upserts the
+/// render components with the same identity/order mapping as
+/// [`reconcile`], moving values instead of cloning them.
+pub fn reconcile_logic(world: &mut World, logic: &mut World) {
+    use ranim_core::logic::{ExtractedItems, SceneOrder as LogicSceneOrder};
+
+    world.init_resource::<CoreItemEntities>();
+
+    let mut ordered: Vec<(u32, u32, Entity)> = Vec::new();
+    for eref in logic.iter_entities() {
+        let Some(order) = eref.get::<LogicSceneOrder>() else {
+            continue;
+        };
+        ordered.push((order.animation_id, order.part, eref.id()));
+    }
+    ordered.sort();
+
+    let mut seen = CoreItemIdSet::with_capacity_and_hasher(
+        ordered.len(),
+        CoreItemIdBuildHasher::default(),
+    );
+    let mut order = 0usize;
+    let mut current_animation = None;
+    let mut flat_part = 0usize;
+    for (animation_id, _slot, logic_entity) in ordered {
+        if current_animation != Some(animation_id) {
+            current_animation = Some(animation_id);
+            flat_part = 0;
+        }
+        let mut entity_mut = logic.entity_mut(logic_entity);
+        let mut extracted = entity_mut.get_mut::<ExtractedItems>().unwrap();
+        for item in extracted.0.drain(..) {
+            let id = (animation_id as usize, flat_part);
+            flat_part += 1;
+            assert!(seen.insert(id), "duplicate CoreItem id {id:?}");
+            upsert_core_item(world, id, order, item);
+            order += 1;
+        }
+    }
+
+    despawn_stale(world, &seen);
 }
 
 fn replace_component<T>(world: &mut World, entity: Entity, value: &T)
@@ -183,5 +254,37 @@ mod tests {
         assert!(world.get::<MeshItem>(entity).is_some());
         assert!(world.get::<VItem>(entity).is_none());
         assert!(world.get::<CameraFrame>(entity).is_none());
+    }
+}
+
+#[cfg(test)]
+mod logic_tests {
+    use ranim_core::{
+        RanimScene, ScenePlayer,
+        animation::{AnimationExt, StaticAnim},
+        core_item::{camera_frame::CameraFrame, vitem::VItem},
+    };
+
+    use super::*;
+
+    #[test]
+    fn reconcile_logic_moves_camera_and_vitem_into_render_world() {
+        let mut scene = RanimScene::new();
+        scene.play(CameraFrame::default().show().with_duration(1.0));
+        scene.play(VItem::default().show().with_duration(1.0));
+        let mut player = ScenePlayer::new(scene.seal());
+
+        player.materialize_at(0.5);
+        let mut logic = player.take_world();
+        let mut world = World::new();
+        reconcile_logic(&mut world, &mut logic);
+        player.put_world(logic);
+
+        assert_eq!(
+            world.query::<&CameraFrame>().iter(&world).count(),
+            1,
+            "camera must reach the render world"
+        );
+        assert_eq!(world.query::<&VItem>().iter(&world).count(), 1);
     }
 }

--- a/src/cmd/preview/mod.rs
+++ b/src/cmd/preview/mod.rs
@@ -27,9 +27,6 @@ pub enum RanimPreviewAppCmd {
     ReloadScene(Scene, Sender<()>),
 }
 
-/// Default logic grid resolution (Hz), per the time model design.
-const DEFAULT_LOGIC_FPS: f64 = 120.0;
-
 #[cfg(all(not(target_family = "wasm"), feature = "render"))]
 enum ExportProgress {
     /// (current_frame, total_frames)
@@ -163,7 +160,7 @@ impl RanimPreviewApp {
         info!("Getting timelines info...");
         let animation_infos = timeline.get_animation_infos();
         let total_secs = timeline.total_secs();
-        let evaluator = timeline.into_evaluator(DEFAULT_LOGIC_FPS);
+        let evaluator = timeline.into_evaluator();
         info!("Total {} root animations", animation_infos.len());
 
         let (cmd_tx, cmd_rx) = unbounded();
@@ -267,7 +264,7 @@ impl RanimPreviewApp {
                         TimelineState::new(timeline.total_secs(), animation_infos);
                     self.timeline_state.current_sec =
                         old_cur_second.clamp(0.0, self.timeline_state.total_sec);
-                    self.evaluator = timeline.into_evaluator(DEFAULT_LOGIC_FPS);
+                    self.evaluator = timeline.into_evaluator();
                     self.store.update(std::iter::empty());
                     self.need_eval = true;
 

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -158,9 +158,7 @@ pub fn render_scene_job(
     let scene = constructor.build_scene();
     trace!("Build timeline cost: {:?}", t.elapsed());
 
-    // Default logic grid 120 Hz (per the time model design); render fps only
-    // decides which logic states are sampled.
-    let mut evaluator = scene.into_evaluator(DEFAULT_LOGIC_FPS);
+    let mut evaluator = scene.into_evaluator();
 
     let mut app = RanimRenderApp::new(name, scene_config, &output, buffer_count);
     app.render_scene_with_progress(&mut evaluator, on_progress);
@@ -169,9 +167,6 @@ pub fn render_scene_job(
         app.render_capture_marks(&mut evaluator);
     }
 }
-
-/// Default logic grid resolution (Hz), per the time model design.
-const DEFAULT_LOGIC_FPS: f64 = 120.0;
 
 /// Handle to the background render thread, used to submit frame data from the main thread.
 ///

--- a/src/cmd/render/mod.rs
+++ b/src/cmd/render/mod.rs
@@ -158,9 +158,23 @@ pub fn render_scene_job(
     let scene = constructor.build_scene();
     trace!("Build timeline cost: {:?}", t.elapsed());
 
+    let mut app = RanimRenderApp::new(name, scene_config, &output, buffer_count);
+
+    // Experimental M2 path: drive rendering from the retained `LogicWorld`
+    // (direct extraction, world exchange) instead of the transport frame.
+    if std::env::var("RANIM_SESSION").is_ok_and(|v| v.eq_ignore_ascii_case("player")) {
+        let mut player = ranim_core::ScenePlayer::new(scene);
+        app.render_scene_player_with_progress(&mut player, on_progress);
+
+        if capture_marks && !player.time_marks().is_empty() {
+            let mut evaluator = constructor.build_scene().into_evaluator();
+            app.render_capture_marks(&mut evaluator);
+        }
+        return;
+    }
+
     let mut evaluator = scene.into_evaluator();
 
-    let mut app = RanimRenderApp::new(name, scene_config, &output, buffer_count);
     app.render_scene_with_progress(&mut evaluator, on_progress);
 
     if capture_marks && !evaluator.time_marks().is_empty() {
@@ -168,12 +182,23 @@ pub fn render_scene_job(
     }
 }
 
+/// Frame payload exchanged between the main thread and the render worker.
+///
+/// `Buffer` is the classic transport frame (pure path); `Logic` hands the
+/// `LogicWorld` itself over for render-side direct extraction (world
+/// exchange) and the worker hands it back after rendering.
+enum FrameExchange {
+    Buffer(RenderFrame),
+    Logic(bevy_ecs::world::World),
+}
+
 /// Handle to the background render thread, used to submit frame data from the main thread.
 ///
 /// Dropping this handle closes the submission channel and terminates the worker thread loop.
 pub struct RenderThreadHandle {
-    submit_frame_tx: async_channel::Sender<RenderFrame>,
-    back_rx: async_channel::Receiver<RenderFrame>,
+    submit_frame_tx: async_channel::Sender<FrameExchange>,
+    back_frame_rx: async_channel::Receiver<RenderFrame>,
+    back_logic_rx: async_channel::Receiver<bevy_ecs::world::World>,
     worker_rx: async_channel::Receiver<RenderWorker>,
 }
 
@@ -182,12 +207,26 @@ impl RenderThreadHandle {
     pub fn sync_and_submit(&self, f: impl FnOnce(&mut RenderFrame)) {
         let mut store = self.get_store();
         f(&mut store);
-        self.submit_frame_tx.send_blocking(store).unwrap();
+        self.submit_frame_tx
+            .send_blocking(FrameExchange::Buffer(store))
+            .unwrap();
     }
 
     /// Retrieves a previously rendered [`RenderFrame`] from the background thread for reuse.
     pub fn get_store(&self) -> RenderFrame {
-        self.back_rx.recv_blocking().unwrap()
+        self.back_frame_rx.recv_blocking().unwrap()
+    }
+
+    /// Submits the `LogicWorld` for direct extraction (world exchange).
+    pub fn submit_logic(&self, world: bevy_ecs::world::World) {
+        self.submit_frame_tx
+            .send_blocking(FrameExchange::Logic(world))
+            .unwrap();
+    }
+
+    /// Receives the `LogicWorld` back after the worker rendered it.
+    pub fn recv_logic(&self) -> bevy_ecs::world::World {
+        self.back_logic_rx.recv_blocking().unwrap()
     }
 
     /// Closes the submission channel, waits for the background thread to finish, and returns the [`RenderWorker`].
@@ -316,10 +355,11 @@ impl RenderWorker {
     /// The background thread loops over incoming [`RenderFrame`]s, rendering and outputting frames using multi-buffered async readback.
     pub fn yeet(self) -> RenderThreadHandle {
         let (submit_frame_tx, submit_frame_rx) = async_channel::bounded(1);
-        let (back_tx, back_rx) = async_channel::bounded(1);
+        let (back_frame_tx, back_frame_rx) = async_channel::bounded(1);
+        let (back_logic_tx, back_logic_rx) = async_channel::bounded(1);
         let (worker_tx, worker_rx) = async_channel::bounded(1);
 
-        back_tx.send_blocking(RenderFrame::default()).unwrap();
+        back_frame_tx.send_blocking(RenderFrame::default()).unwrap();
         std::thread::spawn(move || {
             let mut worker = self;
             let n = worker.render_textures.len();
@@ -327,7 +367,7 @@ impl RenderWorker {
             let mut cur = 0usize;
             let mut pending: VecDeque<(usize, u64)> = VecDeque::new();
 
-            while let Ok(store) = submit_frame_rx.recv_blocking() {
+            while let Ok(exchange) = submit_frame_rx.recv_blocking() {
                 // Drain oldest pending readback if all targets are occupied
                 if pending.len() >= n {
                     let (prev, prev_fc) = pending.pop_front().unwrap();
@@ -335,21 +375,33 @@ impl RenderWorker {
                     worker.output_frame_from(prev, prev_fc);
                 }
 
-                // Render current frame and start async readback
-                worker.renderer.render_frame(
-                    &mut worker.render_textures[cur],
-                    worker.clear_color,
-                    &store,
-                );
-                worker.render_textures[cur].start_readback(&worker.ctx);
+                // Render current frame and start async readback, then return
+                // the payload early so main thread can eval the next frame
+                // while GPU processes the readback
+                match exchange {
+                    FrameExchange::Buffer(store) => {
+                        worker.renderer.render_frame(
+                            &mut worker.render_textures[cur],
+                            worker.clear_color,
+                            &store,
+                        );
+                        worker.render_textures[cur].start_readback(&worker.ctx);
+                        back_frame_tx.send_blocking(store).unwrap();
+                    }
+                    FrameExchange::Logic(mut logic) => {
+                        worker.renderer.render_logic_frame(
+                            &mut worker.render_textures[cur],
+                            worker.clear_color,
+                            &mut logic,
+                        );
+                        worker.render_textures[cur].start_readback(&worker.ctx);
+                        back_logic_tx.send_blocking(logic).unwrap();
+                    }
+                };
 
                 pending.push_back((cur, frame_count));
                 frame_count += 1;
                 cur = (cur + 1) % n;
-
-                // Return store early so main thread can eval next frame
-                // while GPU processes the readback
-                back_tx.send_blocking(store).unwrap();
 
                 // Now try to drain any completed readbacks while we wait
                 // for the next frame from the main thread
@@ -373,7 +425,8 @@ impl RenderWorker {
         });
         RenderThreadHandle {
             submit_frame_tx,
-            back_rx,
+            back_frame_rx,
+            back_logic_rx,
             worker_rx,
         }
     }
@@ -560,6 +613,73 @@ impl RanimRenderApp {
             start.elapsed(),
         );
         trace!("render timeline cost: {:?}", start.elapsed());
+    }
+
+    /// Renders the entire scene driven by a [`ScenePlayer`](ranim_core::ScenePlayer)
+    /// (M2 direct extraction): each frame materializes the `LogicWorld`, hands
+    /// it to the render worker (world exchange), and takes it back — no
+    /// transport frame is materialized.
+    #[instrument(skip_all)]
+    pub fn render_scene_player_with_progress(
+        &mut self,
+        player: &mut ranim_core::ScenePlayer,
+        on_progress: Option<Box<dyn Fn(u64, u64) + Send>>,
+    ) {
+        let start = Instant::now();
+
+        let worker_thread = self.render_worker.take().unwrap().yeet();
+
+        let total_secs = player.total_secs();
+        let fps = self.fps as f64;
+        let raw_frames = total_secs * fps;
+        let n = raw_frames.ceil() as u64;
+        let num_frames = if (raw_frames - raw_frames.round()).abs() < 1e-9 {
+            n
+        } else {
+            n + 1
+        };
+        let style = ProgressStyle::with_template(
+                "[{elapsed_precise}] [{wide_bar:.cyan/blue}] frame {human_pos}/{human_len} (eta {eta}) {msg}",
+            )
+            .unwrap()
+            .with_key("eta", |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
+            })
+            .progress_chars("#>-");
+
+        let span = Span::current();
+        span.pb_set_style(&style);
+        span.pb_set_length(num_frames);
+
+        (0..num_frames)
+            .map(|f| (f as f64 / fps).min(total_secs))
+            .enumerate()
+            .for_each(|(i, sec)| {
+                player.materialize_at(sec);
+                worker_thread.submit_logic(player.take_world());
+                player.put_world(worker_thread.recv_logic());
+
+                span.pb_inc(1);
+                if let Some(cb) = &on_progress {
+                    cb(i as u64 + 1, num_frames);
+                }
+                span.pb_set_message(
+                    format!(
+                        "rendering {:.1?}/{:.1?}",
+                        Duration::from_secs_f64(sec),
+                        Duration::from_secs_f64(total_secs)
+                    )
+                    .as_str(),
+                );
+            });
+        self.render_worker.replace(worker_thread.retrive());
+
+        info!(
+            "rendered {} frames({:?}) in {:?} (logic world)",
+            num_frames,
+            Duration::from_secs_f64(player.total_secs()),
+            start.elapsed(),
+        );
     }
 
     /// Renders and saves screenshots for every [`TimeMark::Capture`] mark on the timeline.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 
 #[cfg(feature = "anims")]
 pub use ranim_anims as anims;
+pub use bevy_ecs;
 pub use ranim_core as core;
 #[cfg(feature = "items")]
 pub use ranim_items as items;


### PR DESCRIPTION
- **feat**: M2 LogicWorld stage 1 — retained ECS world driven by `ScenePlayer`, unified with `SceneEvaluator` behind `SceneSession`; render-side direct extraction (world exchange + `reconcile_logic`), gated by `RANIM_SESSION=player`
- **refactor**: `DynItem` carries a self-materialize hook (single construction site) replacing the parallel `materialize_dyn` traversal; drop the vestigial `logic_fps`
- **perf**: fuse extraction into materialize and drain in collect — the player now pays the same single clone per item per frame as the evaluator
- **test**: frame-identity/seek/lifecycle/type-change logic tests; `session` + `extract_path` criterion benches; `profile_session` / `profile_extract_path` samply targets

### Breaking Changes

- **`EvalDyn` / `Animation` / `Placeable` / `StaticAnimRequirement` bounds**: `E::Output` now requires `MaterializeOut` (was `AnyExtractCoreItem`); custom item/state types need `Component` + an explicit `LogicItem` impl (see `logic_impls.rs`, `double_pendulum`)
- **`DynItem`**: tuple struct → named fields; construct via `DynItem::new<T: MaterializeOut>` (it had exactly one construction site)
- **`SceneEvaluator::new` / `SealedRanimScene::into_evaluator` / `SceneSession::from_sealed`**: the inert `logic_fps` parameter is removed
- **`ItemExtractor` / `ScenePlayer::extract`**: removed (extraction is fused into materialize)

---

## LogicWorld 与 ScenePlayer

The animation tree is type-erased at two points (cell layer `Box<dyn EvalDyn>`, output layer `DynItem`). Materialization capability must be captured at the erasure point: `DynItem` carries a hook monomorphized at its single construction site, so the materialize phase is just the shared `eval` traversal followed by each item upserting itself by `(animation_id, part)` identity — one routing implementation, and static snapshots (`hold`, lagged fills) of custom types materialize correctly.

`ScenePlayer` mirrors `SceneEvaluator` (pure `eval_alpha` query, no stepping/seek bookkeeping) and both implement `SceneSession`; outputs are frame-identical (tested).

## Direct extraction into the render world

`EvaluatedFrame`/`RenderFrame` is a transport artifact. The direct path hands the `LogicWorld` to the render worker (world exchange) and `reconcile_logic` drains `ExtractedItems` straight into render components (move semantics, change ticks preserved). The buffered evaluator path is untouched.

**The dylib rule (measured)**: bevy component registration is `TypeId`-keyed and `TypeId`s differ across a dylib boundary — a hook monomorphized in the scene dylib registered components invisible to the host. Materialization is therefore split: host-side fn pointer (`MaterializeCtx.upsert`) writes identity/order/extraction (the embryonic stage-3 registry), hook-side only extracts and inserts the typed component.

## Benchmarks (samply, 1000Hz total-time attribution x time window, transform_squares 50x50, 1800 frames/path, ms/frame)

| phase (ms/frame) | evaluator | player | buffered | direct |
|---|---|---|---|---|
| animation tree eval (`eval_at`) | 0.22 | 0.25 | 0.27 | 0.29 |
| extract clone (T -> CoreItem) | 0.34 | 0.34 | 0.40 | 0.39 |
| LogicWorld upsert bookkeeping | - | 0.51 | - | 0.46 |
|   of which bevy `Column::replace` | - | 0.17 | - | 0.23 |
|   of which seen/index/Vec alloc/insert | - | 0.34 | - | 0.23 |
| frame buffer transport & cleanup | 0.23 | 0.03 | 0.42 | 0.13 |
| reconcile into render world | - | - | 0.21 | 0.29 |
| **total** | **0.79** | **1.13** | **1.30** | **1.56** |

Paths: **evaluator** = `sample_at` only (baseline); **player** = `materialize_at` only; **buffered** = evaluator -> `RenderFrame` -> `reconcile` (current production); **direct** = player -> world exchange -> `reconcile_logic`.

The remaining gap is LogicWorld bookkeeping (implementation overhead, not structural): compare-before-insert, extraction-buffer reuse, and sort-free `reconcile_logic` are the recorded next optimizations. e2e verified: `basic` renders 192 frames via the direct path, output identical to the evaluator path within codec noise.

---

- **feat**：M2 LogicWorld stage 1 —— 由 `ScenePlayer` 驱动的 retained ECS world，与 `SceneEvaluator` 统一在 `SceneSession` 之后；渲染侧直接提取（world exchange + `reconcile_logic`），以 `RANIM_SESSION=player` 开启
- **refactor**：`DynItem` 携带自物化钩子（唯一构造点捕获），取代平行的 `materialize_dyn` 遍历；删除已无意义的 `logic_fps`
- **perf**：extract 融合进 materialize、collect 改为 drain——player 与 evaluator 每 item 每帧同为一次 clone
- **test**：帧一致性/seek/生命周期/槽位类型变化测试；`session` 与 `extract_path` 基准；`profile_session`/`profile_extract_path` samply 目标

### Breaking Changes

- **`EvalDyn` / `Animation` / `Placeable` / `StaticAnimRequirement` bound**：`E::Output` 现在要求 `MaterializeOut`（原 `AnyExtractCoreItem`）；自定义 item/状态类型需要 derive `Component` 并显式实现 `LogicItem`（见 `logic_impls.rs`、`double_pendulum`）
- **`DynItem`**：元组结构体改为命名字段，经 `DynItem::new<T: MaterializeOut>` 构造（全仓原只有一个构造点）
- **`SceneEvaluator::new` / `SealedRanimScene::into_evaluator` / `SceneSession::from_sealed`**：删除已无作用的 `logic_fps` 参数
- **`ItemExtractor` / `ScenePlayer::extract`**：已删除（extract 融合进 materialize）

---

## LogicWorld 与 ScenePlayer

动画表示有两个类型擦除点（cell 层 `Box<dyn EvalDyn>`、输出层 `DynItem`），物化能力必须在擦除点捕获：`DynItem` 在唯一构造点单态化出自物化钩子，物化阶段就是共享的 `eval` 遍历加上每个 item 按 `(animation_id, part)` 身份自物化——路由只有一份，`hold`/lagged fill 静态快照中的自定义类型也能正确物化。

`ScenePlayer` 与 `SceneEvaluator` 同构（纯 `eval_alpha` 查询，无步进/seek 簿记），均实现 `SceneSession`；输出逐帧一致（有测试锁定）。

## 直接提取进渲染世界

`EvaluatedFrame`/`RenderFrame` 帧缓冲只是传输工件。直接路径把 `LogicWorld` 交给渲染线程（world exchange），`reconcile_logic` 将 `ExtractedItems` 直接 drain 进渲染组件（move 语义、保留变更 tick）；evaluator 缓冲路径不受影响。

**dylib 规则（实测）**：bevy 组件注册以 `TypeId` 为键、跨 dylib 不同——dylib 内单态化的钩子直接写 world 会注册宿主不可见的组件。因此物化分侧：宿主 fn 指针（`MaterializeCtx.upsert`）写身份/顺序/提取产物（stage 3 registry 雏形），钩子侧只做提取与 typed 组件插入。

## 基准（samply 1000Hz total-time 归因 x 时间窗，transform_squares 50x50，各 1800 帧，ms/帧）

| 阶段（ms/帧） | evaluator | player | buffered | direct |
|---|---|---|---|---|
| 动画树求值 `eval_at` | 0.22 | 0.25 | 0.27 | 0.29 |
| extract clone（T→CoreItem） | 0.34 | 0.34 | 0.40 | 0.39 |
| LogicWorld upsert 簿记 | – | 0.51 | – | 0.46 |
|   其中 bevy `Column::replace` | – | 0.17 | – | 0.23 |
|   其中 seen/索引/Vec 分配/insert | – | 0.34 | – | 0.23 |
| 帧缓冲搬运与清理 | 0.23 | 0.03 | 0.42 | 0.13 |
| reconcile → 渲染世界 | – | – | 0.21 | 0.29 |
| **合计** | **0.79** | **1.13** | **1.30** | **1.56** |

路径定义：**evaluator** = 仅 `sample_at`（基线）；**player** = 仅 `materialize_at`；**buffered** = evaluator → `RenderFrame` → `reconcile`（现行生产路径）；**direct** = player → world exchange → `reconcile_logic`。

剩余差距是 LogicWorld 簿记（实现开销而非结构差异）：写前比较、提取缓冲复用、`reconcile_logic` 免排序是已记录的后续优化。e2e 已验证：basic 场景经直接路径渲染 192 帧，输出与 evaluator 路径在编码噪声内一致。