### PR TITLE
fix(ranim-cli): ignore access events in preview file watcher

### DIFF
--- a/packages/ranim-cli/src/cli/preview.rs
+++ b/packages/ranim-cli/src/cli/preview.rs
@@ -10,7 +10,7 @@ use ranim::cmd::preview::{RanimPreviewApp, RanimPreviewAppCmd};
 
 use anyhow::{Context, Result};
 use async_channel::{Receiver, bounded, unbounded};
-use notify::RecursiveMode;
+use notify::{EventKind, RecursiveMode};
 use tracing::{error, info, trace};
 
 use crate::{RanimUserLibraryBuilder, cli::CliArgs, resolve_build_target, workspace::Workspace};
@@ -22,6 +22,13 @@ fn is_vcs_metadata(path: &Path) -> bool {
             Some(".git" | ".hg" | ".svn")
         )
     })
+}
+
+// Access events are plain reads. The build itself opens the watched manifests
+// (`.cargo/config.toml`, every crate's `Cargo.toml`, `Cargo.lock`), so reacting
+// to them makes each build trigger the next one in an endless loop.
+fn is_rebuild_event(event: &DebouncedEvent) -> bool {
+    !matches!(event.kind, EventKind::Access(_) | EventKind::Other)
 }
 
 fn watch_krate(
@@ -41,6 +48,7 @@ fn watch_krate(
                 return;
             };
             evt.retain(|event| !event.paths.iter().all(|path| is_vcs_metadata(path)));
+            evt.retain(is_rebuild_event);
             if !evt.is_empty() {
                 _ = tx.try_send(evt)
             }
@@ -213,9 +221,22 @@ pub fn preview_command(args: &CliArgs, scene_name: &Option<String>) -> Result<()
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{
+        path::{Path, PathBuf},
+        time::Instant,
+    };
 
-    use super::is_vcs_metadata;
+    use notify::event::{
+        AccessKind, AccessMode, CreateKind, DataChange, ModifyKind, RemoveKind, RenameMode,
+    };
+    use notify::{Event, EventKind};
+
+    use super::{DebouncedEvent, is_rebuild_event, is_vcs_metadata};
+
+    fn event_of_kind(kind: EventKind) -> DebouncedEvent {
+        let event = Event::new(kind).add_path(PathBuf::from("src/main.rs"));
+        DebouncedEvent::new(event, Instant::now())
+    }
 
     #[test]
     fn recognizes_vcs_metadata_at_any_depth() {
@@ -223,5 +244,29 @@ mod tests {
         assert!(is_vcs_metadata(Path::new("repo/nested/.hg/store")));
         assert!(is_vcs_metadata(Path::new("repo/.svn/wc.db")));
         assert!(!is_vcs_metadata(Path::new("repo/src/git.rs")));
+    }
+
+    #[test]
+    fn rebuild_on_create_modify_remove_only() {
+        for kind in [
+            EventKind::Create(CreateKind::File),
+            EventKind::Modify(ModifyKind::Data(DataChange::Any)),
+            EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+            EventKind::Remove(RemoveKind::File),
+        ] {
+            assert!(is_rebuild_event(&event_of_kind(kind)), "{kind:?}");
+        }
+    }
+
+    #[test]
+    fn ignore_access_and_other_events() {
+        for kind in [
+            EventKind::Access(AccessKind::Open(AccessMode::Any)),
+            EventKind::Access(AccessKind::Close(AccessMode::Read)),
+            EventKind::Access(AccessKind::Read),
+            EventKind::Other,
+        ] {
+            assert!(!is_rebuild_event(&event_of_kind(kind)), "{kind:?}");
+        }
     }
 }


### PR DESCRIPTION
Closes: N/A

- **fix**: The preview file watcher no longer triggers rebuilds on `Access` events (`Open`/`Close`/`Read`) or `Other` events; only `Create`, `Modify`, and `Remove` activity starts a build.

---

## Problem

The preview watcher's debounced callback forwarded every debounced event to the rebuild loop without filtering by event kind:

```rust
// before: any event kind reached the daemon loop
evt.retain(|event| !event.paths.iter().all(|path| is_vcs_metadata(path)));
if !evt.is_empty() { tx.try_send(evt) }
```

The daemon loop then called `builder.start_build()` on every batch. On Linux (inotify), plain reads of watched files emit `Access(Open)`/`Access(Close)` events, and a build reads many watched files itself — `.cargo/config.toml`, every workspace member's `Cargo.toml`, and `Cargo.lock`. So each build produced a fresh batch of access events over watched paths, which started another build, which produced more access events — an endless cancel/restart cycle:

```
Access(Open): [.cargo/config.toml]
Start build
Access(Open): [Cargo.toml, ... member Cargo.tomls, Cargo.lock]
Canceling previous build...
Build cancelled
Start build
...  # repeats forever
```

Reads by any other process over the watched tree (e.g. rust-analyzer opening manifests) triggered spurious rebuilds the same way.

## Fix

Filter non-actionable event kinds out in the debouncer callback, before they enter the channel:

```rust
fn is_rebuild_event(event: &DebouncedEvent) -> bool {
    !matches!(event.kind, EventKind::Access(_) | EventKind::Other)
}
```

Writes still surface as `Modify(Data(...))` (Linux emits `IN_MODIFY` before `IN_CLOSE_WRITE`), so dropping `Access` loses no real triggers while breaking the self-feedback loop.

## Tests

Added unit tests covering both directions: Create/Modify/Remove pass through, Access(Open/Close/Read) and Other are dropped.

---

## 问题

preview 的文件监听回调不过滤事件类型，把包括 `Access(Open/Close/Read)` 在内的所有事件都送进重建循环。而在 Linux（inotify）上，纯读取操作也会产生 Access 事件，并且构建过程本身就要读取被监听的 `.cargo/config.toml`、各 crate 的 `Cargo.toml` 和 `Cargo.lock`——于是每次构建都会生成一批新的 Access 事件，触发下一次构建，形成无休止的取消/重启循环（见上文日志）。其他进程（如 rust-analyzer）读取监听范围内的文件同样会触发虚假重建。

## 修复

在 debounce 回调里把不可操作的 `Access` 与 `Other` 事件过滤掉，仅保留 `Create`/`Modify`/`Remove` 触发重建。写入在 Linux 上仍会产生 `IN_MODIFY`（即 `Modify(Data(...))`），因此丢弃 Access 不会漏掉任何真实变更，同时切断了自激回路。

## 测试

新增单元测试覆盖两个方向：Create/Modify/Remove 通过，Access(Open/Close/Read) 与 Other 被过滤。