### PR TITLE
feat(core): forward Partial and Empty through Transformed

### DIFF
--- a/packages/ranim-core/src/core_item/transformed.rs
+++ b/packages/ranim-core/src/core_item/transformed.rs
@@ -1,5 +1,7 @@
 //! A wrapper that attaches a typed external transform to an item.
 
+use std::ops::Range;
+
 use glam::{DAffine3, DVec3, dvec3};
 
 use crate::{
@@ -8,8 +10,8 @@ use crate::{
     color::{AlphaColor, Srgb},
     core_item::CoreItem,
     traits::{
-        Alignable, ApplyTransform, Diag, FillColor, Interpolatable, Opacity, Rigid, Similarity,
-        StrokeColor, TransformGroup, Translation,
+        Alignable, ApplyTransform, Diag, Empty, FillColor, Interpolatable, Opacity, Partial, Rigid,
+        Similarity, StrokeColor, TransformGroup, Translation,
     },
 };
 
@@ -226,6 +228,40 @@ impl<T: StrokeColor, G> StrokeColor for Transformed<T, G> {
     fn set_stroke_opacity(&mut self, opacity: f32) -> &mut Self {
         self.inner.set_stroke_opacity(opacity);
         self
+    }
+}
+
+impl<T: Partial, G: Clone> Partial for Transformed<T, G> {
+    /// Take a partial slice of the wrapped item, keeping the pose.
+    ///
+    /// The range is forwarded to `inner`, so the partial geometry is taken in
+    /// the item's own coordinates, while the stored transform `G` is cloned
+    /// unchanged. The wrapper therefore keeps its placement while the visible
+    /// geometry grows from the slice, which is what create-style animations
+    /// expect.
+    fn get_partial(&self, range: Range<f64>) -> Self {
+        Transformed::new(self.inner.get_partial(range), self.transform.clone())
+    }
+
+    /// Take a closed partial slice of the wrapped item, keeping the pose.
+    ///
+    /// Like [`get_partial`](Self::get_partial), but the inner slice is closed
+    /// so partially shown curves have caps at both ends; the wrapper's
+    /// transform is preserved.
+    fn get_partial_closed(&self, range: Range<f64>) -> Self {
+        Transformed::new(self.inner.get_partial_closed(range), self.transform.clone())
+    }
+}
+
+impl<T: Empty, G: TransformGroup> Empty for Transformed<T, G> {
+    /// Create an empty placeholder of a wrapped item.
+    ///
+    /// The inner item contributes `T::empty()` while the pose is `G::identity()`:
+    /// an empty placeholder carries no geometry, so there is no meaningful
+    /// placement to preserve — identity keeps it neutral for composition until
+    /// real content is placed on it.
+    fn empty() -> Self {
+        Transformed::new(T::empty(), G::identity())
     }
 }
 
@@ -543,5 +579,81 @@ mod tests {
             }
             _ => panic!("expected VItem"),
         }
+    }
+
+    /// A minimal stand-in for the geometry traits: `ranim-core` itself has no
+    /// concrete `Partial` type, so a partial slice is modelled by recording
+    /// the requested range and whether it was closed.
+    #[derive(Clone, Debug, PartialEq)]
+    struct StubShape {
+        /// The range this shape was last materialized from.
+        range: Range<f64>,
+        closed: bool,
+    }
+
+    impl Partial for StubShape {
+        fn get_partial(&self, range: Range<f64>) -> Self {
+            Self {
+                range,
+                closed: false,
+            }
+        }
+
+        fn get_partial_closed(&self, range: Range<f64>) -> Self {
+            Self {
+                range,
+                closed: true,
+            }
+        }
+    }
+
+    impl Empty for StubShape {
+        fn empty() -> Self {
+            Self {
+                range: 0.0..0.0,
+                closed: false,
+            }
+        }
+    }
+
+    #[test]
+    fn partial_forwards_the_range_and_keeps_the_pose() {
+        let wrapped = StubShape {
+            range: 0.0..1.0,
+            closed: false,
+        }
+        .transformed(Translation(DVec3::X));
+
+        let partial = wrapped.get_partial(0.2..0.8);
+        // The very same range reaches the inner item.
+        assert_eq!(partial.inner.range, 0.2..0.8);
+        assert!(!partial.inner.closed);
+        // The stored pose is cloned untouched.
+        assert_eq!(partial.transform, wrapped.transform);
+        assert_eq!(partial.transform, Translation(DVec3::X));
+
+        let closed = wrapped.get_partial_closed(0.3..0.6);
+        assert_eq!(closed.inner.range, 0.3..0.6);
+        assert!(closed.inner.closed);
+        assert_eq!(closed.transform, wrapped.transform);
+    }
+
+    #[test]
+    fn empty_wrapper_carries_an_identity_pose() {
+        let translation: Transformed<StubShape, Translation> = Empty::empty();
+        assert_eq!(translation.inner, StubShape::empty());
+        assert_eq!(translation.transform, Translation(DVec3::ZERO));
+
+        let rigid: Transformed<StubShape, Rigid> = Empty::empty();
+        assert_eq!(rigid.transform, Rigid::identity());
+
+        let similarity: Transformed<StubShape, Similarity> = Empty::empty();
+        assert_eq!(similarity.transform, Similarity::IDENTITY);
+
+        let diagonal: Transformed<StubShape, Diag> = Empty::empty();
+        assert_eq!(diagonal.transform, Diag(dvec3(1.0, 1.0, 1.0)));
+
+        let affine: Transformed<StubShape, DAffine3> = Empty::empty();
+        assert_eq!(affine.transform, DAffine3::IDENTITY);
     }
 }

--- a/packages/ranim-items/src/vitem/svg.rs
+++ b/packages/ranim-items/src/vitem/svg.rs
@@ -66,7 +66,7 @@ impl FillColor for SvgItem {
 
 impl StrokeColor for SvgItem {
     fn stroke_color(&self) -> AlphaColor<Srgb> {
-        self.0[0].fill_color()
+        self.0[0].stroke_color()
     }
     fn set_stroke_color(&mut self, color: AlphaColor<Srgb>) -> &mut Self {
         self.0.set_stroke_color(color);


### PR DESCRIPTION
- **feat**: Implement `Partial` and `Empty` for `Transformed<T, G>` so wrapped items work with the built-in create/write animations
- **fix**: `SvgItem::stroke_color()` now returns the first inner `VItem`'s stroke color instead of its fill color

### Breaking Changes

None.

## Forwarding `Partial` and `Empty` through `Transformed`

The built-in creation animations require `Clone + Partial + Empty +
Interpolatable` (`CreationRequirement` / `WritingRequirement`). The
generic wrapper `Transformed<T, G>` already implemented
`Interpolatable`, `Alignable`, `Opacity`, `FillColor` and
`StrokeColor`, but did not forward `Partial` or `Empty` — so an item
wrapped in `Transformed` could not be used with `Create` / `Write`:

```rust
use ranim::glam::DVec3;
use ranim::prelude::*;

// Before: compile error — the wrapper misses Partial / Empty
let item = VItem::from(Circle::new(1.0)).transformed(Translation(DVec3::Y));
item.create();
// error[E0277]: `Transformed<VItem, Translation>` doesn't implement `Partial`

// After: forwarding impls exist
impl<T: Partial, G: Clone> Partial for Transformed<T, G>
impl<T: Empty, G: TransformGroup> Empty for Transformed<T, G>
```

Semantics of the new impls:

- `get_partial` / `get_partial_closed` take the partial slice of the
  inner item in its own coordinates and rebuild the wrapper with the
  cloned transform unchanged, so the placement survives while the
  visible geometry grows from the slice.
- `empty()` pairs `T::empty()` with `G::identity()`: an empty
  placeholder carries no geometry, hence no meaningful placement.

Unit tests cover exact range forwarding with a bit-identical stored
pose, closed slices, and identity poses across all storage groups
(`Translation`, `Rigid`, `Similarity`, `Diag`, `DAffine3`).

## Fix `SvgItem::stroke_color`

`StrokeColor::stroke_color()` for `SvgItem` accidentally returned the
first inner `VItem`'s **fill** color instead of its stroke color. It
now forwards to `stroke_color()`, matching the `[T]` blanket impl.
A repo-wide search found nothing relying on the wrong value (the only
reader is the `#[derive(Stroke)]` proc macro, which expects the
correct color), so the fix is behavior-safe.

---

- **feat**: 为 `Transformed<T, G>` 实现 `Partial` 和 `Empty`，使被包装的 item 可以使用内置的 create/write 动画
- **fix**: `SvgItem::stroke_color()` 现在返回第一个内部 `VItem` 的描边色，而不是填充色

### Breaking Changes

无。

## 通过 `Transformed` 转发 `Partial` 与 `Empty`

内置创建类动画要求 `Clone + Partial + Empty + Interpolatable`
（`CreationRequirement` / `WritingRequirement`）。泛型包装器
`Transformed<T, G>` 此前已实现 `Interpolatable`、`Alignable`、
`Opacity`、`FillColor` 和 `StrokeColor`，但没有转发 `Partial` 与
`Empty` —— 因此被 `Transformed` 包装的 item 无法使用 `Create` /
`Write`：

```rust
use ranim::glam::DVec3;
use ranim::prelude::*;

// 之前：编译错误 —— 包装器缺少 Partial / Empty
let item = VItem::from(Circle::new(1.0)).transformed(Translation(DVec3::Y));
item.create();
// error[E0277]: `Transformed<VItem, Translation>` doesn't implement `Partial`

// 之后：存在转发实现
impl<T: Partial, G: Clone> Partial for Transformed<T, G>
impl<T: Empty, G: TransformGroup> Empty for Transformed<T, G>
```

新实现的语义：

- `get_partial` / `get_partial_closed` 在 item 自身坐标系内截取部分
  几何，并用原样克隆的 transform 重建包装器：位置姿态保持不变，
  可见几何从片段中生长。
- `empty()` 由 `T::empty()` 搭配 `G::identity()` 组成：空占位符不
  携带几何，因此也没有有意义的摆放位置。

单元测试覆盖了范围的精确转发与位级一致的存储姿态、闭合切片，以及
所有存储组（`Translation`、`Rigid`、`Similarity`、`Diag`、
`DAffine3`）下的单位姿态。

## 修复 `SvgItem::stroke_color`

`SvgItem` 的 `StrokeColor::stroke_color()` 此前误返回第一个内部
`VItem` 的**填充**色而非描边色。现在改为转发到 `stroke_color()`，
与 `[T]` 的 blanket impl 保持一致。全仓库检索未发现任何依赖错误值
的代码（唯一的读取方是 `#[derive(Stroke)]` 过程宏，其期望的是正确
颜色），因此该修复是行为安全的。
