### PR TITLE
fix(ranim-render): resolve coplanar z-fighting with scene-order depth bias

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,14 @@ crate-type = ["cdylib"]
 wasm = true
 
 [[example]]
+name = "z_fighting"
+path = "examples/z_fighting/lib.rs"
+crate-type = ["cdylib"]
+
+[package.metadata.example.z_fighting]
+wasm = true
+
+[[example]]
 name = "animating_pi"
 path = "examples/animating_pi/lib.rs"
 crate-type = ["cdylib"]

--- a/examples/z_fighting/lib.rs
+++ b/examples/z_fighting/lib.rs
@@ -1,0 +1,252 @@
+//! Z-fighting / draw-order verification.
+//!
+//! Ideal behavior: items occupying the same position are drawn in scene
+//! insertion order (the order they were added to the scene), and the result
+//! is stable (no per-pixel flicker between the two colors).
+//!
+//! Every item is played as its own cell (`r.play(item.show())`), so the frame
+//! contains all items with scene order = play order. Pairs of coplanar items
+//! sit at the same position; the *later-inserted* (blue) item should win
+//! everywhere in the overlap, deterministically.
+//!
+//! Scenes:
+//! - `opaque_front`       : straight-on camera (control — insertion order works).
+//! - `opaque_angled`      : angled ortho camera — reproduction: the
+//!   later-inserted blue circle loses chunks of the overlap to the red square.
+//! - `translucent_front`  : translucent fills go through the OIT path, whose
+//!   compositing order for depth ties is arrival order, not insertion order.
+//! - `z_precision`        : z-gap sweep, straight-on (control — all clean).
+//! - `z_precision_angled` : z-gap sweep, angled. Each square has its own
+//!   color so the streaks identify which square's fragments win: the fighting
+//!   appears for gaps around 1e-4..1e-2 and disappears again at 1e-1.
+//! - `z_sweep`            : one pair whose z separation sweeps through zero.
+//! - `flicker`            : camera orbiting one pair — the winning color
+//!   changes over time on identical scene state (temporal instability).
+
+use ranim::{
+    anims::camera::CameraFrameAnim,
+    color::{AlphaColor, Srgb, palettes::manim},
+    glam::{DVec3, dvec3},
+    items::vitem::geometry::{Circle, Square},
+    prelude::*,
+    utils::rate_functions::linear,
+};
+
+fn square(color: AlphaColor<Srgb>) -> Transformed<Square, Translation> {
+    Square::new(2.0)
+        .with(|s| {
+            s.set_fill_color(color);
+        })
+        .transformed(Translation(dvec3(0.0, 0.0, 0.0)))
+}
+
+fn circle(color: AlphaColor<Srgb>) -> Transformed<Circle, Translation> {
+    Circle::new(1.2)
+        .with(|c| {
+            c.set_fill_color(color);
+        })
+        .transformed(Translation(dvec3(0.0, 0.0, 0.0)))
+}
+
+/// Play `red` then `blue` at the same position `pos` for the whole scene.
+///
+/// Two separate cells: red has the lower scene order and should lose the
+/// overlap against blue everywhere.
+macro_rules! pair {
+    ($r:expr, $red:expr, $blue:expr, $pos:expr, $total:expr) => {{
+        let mut red = $red;
+        let mut blue = $blue;
+        red.transform = Translation($pos);
+        blue.transform = Translation($pos);
+        $r.play(red.show().with_duration($total));
+        $r.play(blue.show().with_duration($total));
+    }};
+}
+
+/// red square + blue circle pair, both lifted to `z`.
+macro_rules! pair_z {
+    ($r:expr, $x:expr, $z:expr, $total:expr) => {{
+        pair!(
+            $r,
+            square(manim::RED_C),
+            circle(manim::BLUE_C),
+            dvec3($x, 0.0, $z),
+            $total
+        );
+    }};
+}
+
+fn angled_ortho_camera() -> CameraFrame {
+    let mut cam = CameraFrame::from_spherical(60f64.to_radians(), 30f64.to_radians(), 30.0);
+    cam.perspective_blend = 0.0;
+    cam
+}
+
+fn setup_camera(r: &mut RanimScene, dur: f64) {
+    r.play(CameraFrame::default().show().with_duration(dur));
+}
+
+fn capture(r: &mut RanimScene, total: f64, name: &str) {
+    r.insert_time_mark(total - 0.2, TimeMark::Capture(name.to_string()));
+}
+
+/// Straight-on ortho camera:
+/// - left pair: identical squares at z=0 (control, insertion order)
+/// - middle pair: square + circle at z=0
+/// - right pair: square + circle at z=0.5
+#[scene]
+#[output(dir = "./output/z_fighting")]
+fn opaque_front(r: &mut RanimScene) {
+    let total = 2.2;
+    setup_camera(r, total);
+
+    pair!(
+        r,
+        square(manim::RED_C),
+        square(manim::BLUE_C),
+        dvec3(-4.5, 0.0, 0.0),
+        total
+    );
+    pair_z!(r, 0.0, 0.0, total);
+    pair_z!(r, 4.5, 0.5, total);
+
+    capture(r, total, "opaque_front.png");
+}
+
+/// Same layout as `opaque_front`, but the ortho camera looks from an angle,
+/// so the items' planes are no longer perpendicular to the view direction.
+#[scene]
+#[output(dir = "./output/z_fighting")]
+fn opaque_angled(r: &mut RanimScene) {
+    let total = 2.2;
+    r.play(angled_ortho_camera().show().with_duration(total));
+
+    pair!(
+        r,
+        square(manim::RED_C),
+        square(manim::BLUE_C),
+        dvec3(-4.5, 0.0, 0.0),
+        total
+    );
+    pair_z!(r, 0.0, 0.0, total);
+    pair_z!(r, 4.5, 0.5, total);
+
+    capture(r, total, "opaque_angled.png");
+}
+
+/// Straight-on camera, translucent fills (OIT path):
+/// - left pair: red then blue, both 50% alpha, same position
+/// - right pair: opaque red, then 50% blue on top
+#[scene]
+#[output(dir = "./output/z_fighting")]
+fn translucent_front(r: &mut RanimScene) {
+    let total = 2.0;
+    setup_camera(r, total);
+
+    pair!(
+        r,
+        square(manim::RED_C.with_alpha(0.5)),
+        square(manim::BLUE_C.with_alpha(0.5)),
+        dvec3(-4.5, 0.0, 0.5),
+        total
+    );
+    pair!(
+        r,
+        square(manim::RED_C),
+        square(manim::BLUE_C.with_alpha(0.5)),
+        dvec3(4.5, 0.0, 0.5),
+        total
+    );
+
+    capture(r, total, "translucent_front.png");
+}
+
+/// square + circle pairs (different geometry, same plane) lifted to z=0.5,
+/// with the blue circle separated by a growing z-gap, straight-on camera.
+/// Control: insertion order holds for every gap.
+#[scene]
+#[output(dir = "./output/z_fighting")]
+fn z_precision(r: &mut RanimScene) {
+    let total = 3.4;
+    setup_camera(r, total);
+
+    let gaps = [0.0, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1];
+    for (i, gap) in gaps.iter().enumerate() {
+        let x = -5.0 + 2.0 * i as f64;
+        pair_z!(r, x, 0.5 + gap, total);
+    }
+
+    capture(r, total, "z_precision.png");
+}
+
+/// Same gaps as `z_precision` but seen from an angle. Each square has its own
+/// fill color so the streaks identify which square's fragments win.
+#[scene]
+#[output(dir = "./output/z_fighting")]
+fn z_precision_angled(r: &mut RanimScene) {
+    let total = 3.4;
+    r.play(angled_ortho_camera().show().with_duration(total));
+
+    let gaps = [0.0, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1];
+    let sq_colors = [
+        manim::RED_C,
+        manim::GREEN_C,
+        manim::YELLOW_C,
+        manim::PURPLE_C,
+        manim::MAROON_C,
+        manim::GOLD_A,
+    ];
+    for (i, gap) in gaps.iter().enumerate() {
+        let x = -5.0 + 2.0 * i as f64;
+        pair!(
+            r,
+            square(sq_colors[i]),
+            circle(manim::BLUE_C),
+            dvec3(x, 0.0, 0.5 + gap),
+            total
+        );
+    }
+
+    capture(r, total, "z_precision_angled.png");
+}
+
+/// Fixed angled camera; the blue circle's z sweeps linearly through the red
+/// square's plane (z 0.45 -> 0.55, square at 0.5). The winner flips cleanly
+/// at delta = 0 at this screen position; the same gap fights at others.
+#[scene]
+#[output(dir = "./output/z_fighting")]
+fn z_sweep(r: &mut RanimScene) {
+    let total = 4.0;
+    r.play(angled_ortho_camera().show().with_duration(total));
+
+    let mut sq = square(manim::RED_C);
+    sq.transform = Translation(dvec3(0.0, 0.0, 0.5));
+    r.play(sq.show().with_duration(total));
+
+    r.play(
+        Pure::new(|alpha| {
+            let z = 0.45 + 0.1 * alpha;
+            let mut ci = circle(manim::BLUE_C);
+            ci.transform = Translation(dvec3(0.0, 0.0, z));
+            ci
+        })
+        .with_duration(total)
+        .with_rate_func(linear),
+    );
+}
+
+/// Slowly orbit a perspective camera around the square+circle pair to show
+/// that the winning color changes over time (instability).
+#[scene]
+#[output(dir = "./output/z_fighting")]
+fn flicker(r: &mut RanimScene) {
+    let total = 4.0;
+    let mut cam = CameraFrame::from_spherical(60f64.to_radians(), 20f64.to_radians(), 8.0);
+    cam.fovy = 50f64.to_radians();
+    r.play(
+        cam.orbit(DVec3::ZERO, 0.4)
+            .with_duration(total)
+            .with_rate_func(linear),
+    );
+    pair_z!(r, 0.0, 0.5, total);
+}

--- a/packages/ranim-render/src/lib.rs
+++ b/packages/ranim-render/src/lib.rs
@@ -114,7 +114,12 @@ impl Renderer {
         world.insert_resource(MeshItemsBuffer::new(ctx));
         world.insert_resource(primitives::viewport::ViewportGpuPacket::new(
             ctx,
-            &ViewportUniform::from_camera_frame(&Default::default(), width, height),
+            &ViewportUniform::from_camera_frame(
+                &Default::default(),
+                width,
+                height,
+                primitives::viewport::DEPTH_ORDER_SPAN,
+            ),
         ));
         world.init_resource::<CoreItemEntities>();
 

--- a/packages/ranim-render/src/pipelines/shaders/mesh_item.wgsl
+++ b/packages/ranim-render/src/pipelines/shaders/mesh_item.wgsl
@@ -7,10 +7,16 @@ struct CameraUniforms {
     proj_mat: mat4x4<f32>,
     view_mat: mat4x4<f32>,
     half_frame_size: vec2<f32>,
+    // Per-order depth bias epsilon: later items are pulled toward the camera
+    // so coplanar surfaces resolve by scene insertion order.
+    bias_epsilon: f32,
+    _pad: u32,
 }
 @group(1) @binding(0) var<uniform> cam_uniforms: CameraUniforms;
 
 @group(2) @binding(0) var<storage> transforms: array<mat4x4<f32>>;
+// Per-mesh global scene order, consumed by the depth-order bias.
+@group(2) @binding(1) var<storage> orders: array<f32>;
 
 struct VertexOutput {
     @builtin(position) frag_pos: vec4<f32>,
@@ -20,6 +26,13 @@ struct VertexOutput {
     @location(3) world_normal: vec3<f32>,
 }
 
+// Pulls a fragment's depth toward the camera by its item's scene order.
+// Within DEPTH_ORDER_SPAN (normalized depth) this makes insertion order the
+// tie-breaker for coplanar surfaces; farther items keep true depth ordering.
+fn ordered_depth(frag_z: f32, mesh_id: u32) -> f32 {
+    return frag_z - cam_uniforms.bias_epsilon * orders[mesh_id];
+}
+
 fn pack_color(color: vec4<f32>) -> u32 {
     let c = vec4<u32>(color * 255.0);
     return (c.r) | (c.g << 8u) | (c.b << 16u) | (c.a << 24u);
@@ -27,6 +40,7 @@ fn pack_color(color: vec4<f32>) -> u32 {
 
 struct FragmentOutput {
     @location(0) color: vec4<f32>,
+    @builtin(frag_depth) depth: f32,
 }
 
 fn compute_lighting(world_pos: vec3<f32>, world_normal: vec3<f32>, base_color: vec4<f32>) -> vec4<f32> {
@@ -52,12 +66,13 @@ fn fs_color(
     @location(1) world_pos: vec3<f32>,
     @location(2) vertex_color: vec4<f32>,
     @location(3) world_normal: vec3<f32>,
-) -> @location(0) vec4<f32> {
+) -> FragmentOutput {
     let color = compute_lighting(world_pos, world_normal, vertex_color);
+    let depth = ordered_depth(frag_pos.z, mesh_id);
 
     // Opaque: output directly
     if (color.a >= 0.99) {
-        return color;
+        return FragmentOutput(color, depth);
     }
 
     // Transparent: write to OIT buffer, then discard
@@ -68,11 +83,11 @@ fn fs_color(
     if (layer_idx < frame.z) {
         let buffer_idx = pixel_idx * frame.z + layer_idx;
         oit_colors[buffer_idx] = pack_color(color);
-        oit_depths[buffer_idx] = frag_pos.z;
+        oit_depths[buffer_idx] = depth;
     }
 
     discard;
-    return vec4<f32>(0.0); // To make wasm happy
+    return FragmentOutput(vec4<f32>(0.0), 1.0); // To make wasm happy
 }
 
 @fragment
@@ -90,7 +105,7 @@ fn fs_depth(
         discard;
     }
 
-    return frag_pos.z;
+    return ordered_depth(frag_pos.z, mesh_id);
 }
 
 @vertex

--- a/packages/ranim-render/src/pipelines/shaders/vitem.wgsl
+++ b/packages/ranim-render/src/pipelines/shaders/vitem.wgsl
@@ -9,8 +9,19 @@ struct CameraUniforms {
     proj_mat: mat4x4<f32>,
     view_mat: mat4x4<f32>,
     half_frame_size: vec2<f32>,
+    // Per-order depth bias epsilon: later items are pulled toward the camera
+    // so coplanar surfaces resolve by scene insertion order.
+    bias_epsilon: f32,
+    _pad: u32,
 }
 @group(1) @binding(0) var<uniform> cam_uniforms: CameraUniforms;
+
+// Pulls a fragment's depth toward the camera by its item's scene order.
+// Within DEPTH_ORDER_SPAN (normalized depth) this makes insertion order the
+// tie-breaker for coplanar surfaces; farther items keep true depth ordering.
+fn ordered_depth(frag_z: f32, order: f32) -> f32 {
+    return frag_z - cam_uniforms.bias_epsilon * order;
+}
 
 // === Merged VItem data (group 2) ===
 
@@ -266,10 +277,11 @@ fn fs_main(
     var out: FragmentOutput;
     let info = item_infos[instance_id];
     let color = render(pos, info);
+    let depth = ordered_depth(frag_pos.z, planes[instance_id].origin.w);
 
     if (color.a >= 0.99) {
         out.color = color;
-        out.depth = frag_pos.z;
+        out.depth = depth;
         return out;
     }
 
@@ -281,7 +293,7 @@ fn fs_main(
     if (layer_idx < frame.z) {
         let buffer_idx = pixel_idx * frame.z + layer_idx;
         oit_colors[buffer_idx] = pack_color(color);
-        oit_depths[buffer_idx] = frag_pos.z;
+        oit_depths[buffer_idx] = depth;
     }
 
     discard;
@@ -303,7 +315,7 @@ fn fs_depth_only(
         discard;
     }
 
-    return frag_pos.z;
+    return ordered_depth(frag_pos.z, planes[instance_id].origin.w);
 }
 
 struct Basis {

--- a/packages/ranim-render/src/primitives/mesh_items.rs
+++ b/packages/ranim-render/src/primitives/mesh_items.rs
@@ -24,6 +24,9 @@ pub struct MeshItemsBuffer {
 
     /// Per-mesh transform matrices (storage buffer, indexed by mesh_id)
     pub(crate) transforms_buffer: WgpuVecBuffer<MeshTransform>,
+    /// Per-mesh global scene order (storage buffer, indexed by mesh_id),
+    /// consumed by the fragment depth-order bias.
+    pub(crate) orders_buffer: WgpuVecBuffer<f32>,
 
     pub(crate) item_count: u32,
     pub(crate) total_vertices: u32,
@@ -55,6 +58,7 @@ impl MeshItemsBuffer {
             ),
             indices_buffer: WgpuVecBuffer::new(ctx, Some("MeshIndices"), index_usage, 1),
             transforms_buffer: WgpuVecBuffer::new(ctx, Some("MeshTransforms"), storage_ro, 1),
+            orders_buffer: WgpuVecBuffer::new(ctx, Some("MeshOrders"), storage_ro, 1),
             item_count: 0,
             total_vertices: 0,
             total_indices: 0,
@@ -64,7 +68,7 @@ impl MeshItemsBuffer {
 
     pub fn update<'a, I>(&mut self, ctx: &WgpuContext, mesh_items: I)
     where
-        I: IntoIterator<Item = &'a MeshItem>,
+        I: IntoIterator<Item = (f32, &'a MeshItem)>,
         I::IntoIter: ExactSizeIterator + Clone,
     {
         let mesh_items = mesh_items.into_iter();
@@ -76,10 +80,14 @@ impl MeshItemsBuffer {
         }
 
         let item_count = mesh_items.len();
-        let total_vertices: usize = mesh_items.clone().map(|m| m.points.len()).sum();
-        let total_indices: usize = mesh_items.clone().map(|m| m.triangle_indices.len()).sum();
+        let total_vertices: usize = mesh_items.clone().map(|(_, m)| m.points.len()).sum();
+        let total_indices: usize = mesh_items
+            .clone()
+            .map(|(_, m)| m.triangle_indices.len())
+            .sum();
 
         let mut transforms = Vec::with_capacity(item_count);
+        let mut all_orders = Vec::with_capacity(item_count);
         let mut all_vertices = Vec::with_capacity(total_vertices);
         let mut all_mesh_ids = Vec::with_capacity(total_vertices);
         let mut all_vertex_colors = Vec::with_capacity(total_vertices);
@@ -88,12 +96,13 @@ impl MeshItemsBuffer {
 
         let mut vertex_offset: u32 = 0;
 
-        for (mesh_idx, mesh) in mesh_items.enumerate() {
+        for (mesh_idx, (order, mesh)) in mesh_items.enumerate() {
             let vc = mesh.points.len() as u32;
 
             transforms.push(MeshTransform {
                 transform: mesh.transform.to_cols_array_2d(),
             });
+            all_orders.push(order);
 
             all_vertices.extend_from_slice(&mesh.points);
             all_mesh_ids.extend(std::iter::repeat_n(mesh_idx as u32, vc as usize));
@@ -127,7 +136,8 @@ impl MeshItemsBuffer {
         self.indices_buffer.set(ctx, &all_indices);
 
         // Storage buffers (bind group recreated on realloc)
-        let any_realloc = self.transforms_buffer.set(ctx, &transforms);
+        let mut any_realloc = self.transforms_buffer.set(ctx, &transforms);
+        any_realloc |= self.orders_buffer.set(ctx, &all_orders);
 
         if any_realloc || self.render_bind_group.is_none() {
             self.render_bind_group = Some(Self::create_render_bind_group(ctx, self));
@@ -194,6 +204,8 @@ impl MeshItemsBuffer {
                 entries: &[
                     // binding 0: transforms (per-mesh, vertex stage)
                     bgl_storage_entry(0, wgpu::ShaderStages::VERTEX),
+                    // binding 1: orders (per-mesh, fragment stage, depth bias)
+                    bgl_storage_entry(1, wgpu::ShaderStages::FRAGMENT),
                 ],
             })
     }
@@ -202,7 +214,10 @@ impl MeshItemsBuffer {
         ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("MeshItems Render BG"),
             layout: &Self::render_bind_group_layout(ctx),
-            entries: &[bg_entry(0, &this.transforms_buffer.buffer)],
+            entries: &[
+                bg_entry(0, &this.transforms_buffer.buffer),
+                bg_entry(1, &this.orders_buffer.buffer),
+            ],
         })
     }
 }

--- a/packages/ranim-render/src/primitives/viewport.rs
+++ b/packages/ranim-render/src/primitives/viewport.rs
@@ -3,6 +3,15 @@ use ranim_core::prelude::CameraFrame;
 
 use crate::utils::{WgpuBuffer, WgpuContext};
 
+/// Total normalized-depth span reserved for scene-order biasing.
+///
+/// Fragments whose true depth differs by less than this span may be reordered
+/// by scene insertion order (later items on top); anything farther apart keeps
+/// true depth ordering. The span is split evenly across all items of a frame
+/// (`epsilon = DEPTH_ORDER_SPAN / item_count`) so the total offset does not
+/// grow with scene size.
+pub const DEPTH_ORDER_SPAN: f32 = 1e-4;
+
 /// Uniforms for the camera
 #[repr(C, align(16))]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
@@ -10,10 +19,17 @@ pub struct ViewportUniform {
     proj_mat: Mat4,
     view_mat: Mat4,
     half_frame_size: Vec2,
-    _padding: [u32; 2],
+    /// Per-order depth bias epsilon, see [`DEPTH_ORDER_SPAN`].
+    bias_epsilon: f32,
+    _padding: u32,
 }
 impl ViewportUniform {
-    pub fn from_camera_frame(camera_frame: &CameraFrame, width: u32, height: u32) -> Self {
+    pub fn from_camera_frame(
+        camera_frame: &CameraFrame,
+        width: u32,
+        height: u32,
+        bias_epsilon: f32,
+    ) -> Self {
         let ratio = width as f64 / height as f64;
         Self {
             proj_mat: camera_frame.projection_matrix(ratio).as_mat4(),
@@ -22,7 +38,8 @@ impl ViewportUniform {
                 (camera_frame.frame_height * ratio) as f32 / 2.0,
                 camera_frame.frame_height as f32 / 2.0,
             ),
-            _padding: [0; 2],
+            bias_epsilon,
+            _padding: 0,
         }
     }
     pub(crate) fn as_bind_group_layout_entry(binding: u32) -> wgpu::BindGroupLayoutEntry {

--- a/packages/ranim-render/src/primitives/vitems.rs
+++ b/packages/ranim-render/src/primitives/vitems.rs
@@ -123,7 +123,7 @@ impl VItemsBuffer {
     /// Pack all VItems into the merged buffers. Called once per frame.
     pub fn update<'a, I>(&mut self, ctx: &WgpuContext, vitems: I)
     where
-        I: IntoIterator<Item = &'a VItem>,
+        I: IntoIterator<Item = (f32, &'a VItem)>,
         I::IntoIter: ExactSizeIterator + Clone,
     {
         let vitems = vitems.into_iter();
@@ -136,8 +136,11 @@ impl VItemsBuffer {
         let item_count = vitems.len();
 
         // Pre-calculate total sizes
-        let total_points: usize = vitems.clone().map(|v| v.points.len()).sum();
-        let total_attrs: usize = vitems.clone().map(|v| v.points.len().div_ceil(2)).sum();
+        let total_points: usize = vitems.clone().map(|(_, v)| v.points.len()).sum();
+        let total_attrs: usize = vitems
+            .clone()
+            .map(|(_, v)| v.points.len().div_ceil(2))
+            .sum();
 
         // Build index table and collect data
         let mut item_infos = Vec::with_capacity(item_count);
@@ -151,7 +154,7 @@ impl VItemsBuffer {
         let mut point_offset: u32 = 0;
         let mut attr_offset: u32 = 0;
 
-        for vitem in vitems {
+        for (order, vitem) in vitems {
             let pc = vitem.points.len() as u32;
             let ac = pc.div_ceil(2);
 
@@ -168,7 +171,9 @@ impl VItemsBuffer {
             let origin = Vec3::new(vitem.points[0].x, vitem.points[0].y, vitem.points[0].z);
             planes.push(PlaneData {
                 normal: Vec4::from((normal, 0.0)),
-                origin: Vec4::from((origin, 0.0)),
+                // origin.w carries the item's global scene order for the
+                // depth-order bias; the plane basis ignores it.
+                origin: Vec4::from((origin, order)),
             });
 
             all_points3d.extend_from_slice(&vitem.points);
@@ -254,8 +259,8 @@ impl VItemsBuffer {
                 entries: &[
                     // binding 0: item_infos
                     bgl_entry(0, vf, false),
-                    // binding 1: planes (normal + origin)
-                    bgl_entry(1, v, false),
+                    // binding 1: planes (normal + origin; origin.w = scene order)
+                    bgl_entry(1, vf, false),
                     // binding 2: clip_boxes
                     bgl_entry(2, v, false),
                     // binding 3: points2d

--- a/packages/ranim-render/src/schedule.rs
+++ b/packages/ranim-render/src/schedule.rs
@@ -127,8 +127,16 @@ pub(crate) fn install_schedules(world: &mut World) {
     );
     view.add_systems(clear.in_set(ViewSystems::Clear));
     view.add_systems(vitem::compute.in_set(ViewSystems::Compute));
-    view.add_systems((vitem::depth, mesh_item::depth).in_set(ViewSystems::Depth));
-    view.add_systems((vitem::color, mesh_item::color).in_set(ViewSystems::Color));
+    view.add_systems(
+        (vitem::depth, mesh_item::depth)
+            .chain()
+            .in_set(ViewSystems::Depth),
+    );
+    view.add_systems(
+        (vitem::color, mesh_item::color)
+            .chain()
+            .in_set(ViewSystems::Color),
+    );
     view.add_systems(oit_resolve::resolve.in_set(ViewSystems::Resolve));
     world.add_schedule(view);
 
@@ -156,7 +164,10 @@ fn prepare_vitems(
 ) {
     let mut items = items.iter().collect::<Vec<_>>();
     items.sort_by_key(|(order, _)| order.0);
-    buffer.update(&ctx, items.into_iter().map(|(_, item)| item));
+    buffer.update(
+        &ctx,
+        items.iter().map(|&(order, item)| (order.0 as f32, item)),
+    );
 }
 
 fn prepare_mesh_items(
@@ -166,7 +177,10 @@ fn prepare_mesh_items(
 ) {
     let mut items = items.iter().collect::<Vec<_>>();
     items.sort_by_key(|(order, _)| order.0);
-    buffer.update(&ctx, items.into_iter().map(|(_, item)| item));
+    buffer.update(
+        &ctx,
+        items.iter().map(|&(order, item)| (order.0 as f32, item)),
+    );
 }
 
 fn begin_frame(ctx: Res<WgpuContext>, mut encoder: ResMut<FrameEncoder>) {
@@ -213,7 +227,17 @@ fn view_driver(world: &mut World) {
 
     let camera = take_single_camera(cameras);
     let dimensions = *world.resource::<RenderDimensions>();
-    let uniform = ViewportUniform::from_camera_frame(&camera, dimensions.width, dimensions.height);
+    // The per-order depth bias epsilon: the fixed span is split evenly across
+    // all items of the frame so the total offset stays bounded.
+    let item_count = world.resource::<VItemsBuffer>().item_count()
+        + world.resource::<MeshItemsBuffer>().item_count();
+    let bias_epsilon = crate::primitives::viewport::DEPTH_ORDER_SPAN / item_count.max(1) as f32;
+    let uniform = ViewportUniform::from_camera_frame(
+        &camera,
+        dimensions.width,
+        dimensions.height,
+        bias_epsilon,
+    );
     world.resource_scope(|world, mut viewport: Mut<ViewportGpuPacket>| {
         viewport.update(world.resource::<WgpuContext>(), &uniform);
     });


### PR DESCRIPTION
- **fix**: Coplanar surfaces now resolve by scene insertion order instead of rasterizer rounding (per-order depth bias in `ranim-render`).
- **test**: New `z_fighting` example reproducing the issue and serving as a pixel-level regression suite.

### Breaking Changes

- **`VItemsBuffer::update` / `MeshItemsBuffer::update` (`ranim-render`)**: the item iterator now yields `(scene_order: f32, item)` pairs so the renderer can bias depth by global scene order. Migration: zip each item with its `SceneOrder` value before passing it in.

---

## Problem

Items occupying the same position are expected to draw in scene insertion order (the order they were added to the scene), and the result must be stable. The CPU-side order chain was already correct (`SceneOrder` → stable sort → instance index), but the GPU side broke the guarantee:

- The depth pass (`Less`, depth write) plus the color pass (`LessEqual`, no depth write) resolve coplanar geometry per-pixel by interpolation rounding; ties fall back to rasterization order, which is not guaranteed within a single draw call.
- Transparent items go through the OIT path, whose layer order is `atomicAdd` arrival order and whose resolve sorts by depth only — coplanar ties keep arrival order instead of insertion order.
- The VItem and MeshItem depth/color passes were unordered relative to each other.

Measured on the new `z_fighting` example (angled ortho camera, red square inserted before a coincident blue circle): 0.9%–45% of the circle's pixels showed the earlier square depending on screen position, scene contents, and camera angle, and the winner flipped over time under a moving camera (blue share 0.16–0.97 across frames). The artifact vanished with the pair rendered alone, changed when unrelated items were added, and did not scale with the near/far range — i.e. the violation is a scheduling/rounding race on depth ties, not a CPU ordering bug.

## Fix: scene-order depth bias

Every item already carries its global `SceneOrder` (the frame index across all item kinds). That order now biases the fragment depth toward the camera:

```wgsl
fn ordered_depth(frag_z: f32, order: f32) -> f32 {
    return frag_z - cam_uniforms.bias_epsilon * order;
}
```

- `bias_epsilon = DEPTH_ORDER_SPAN / item_count` per frame, so the total offset is capped at `DEPTH_ORDER_SPAN` (1e-4 normalized depth ≈ 0.2 world units with the default ±1000 camera) and does not grow with scene size.
- Items whose true depth differs by less than the span resolve by insertion order; anything farther apart keeps true depth ordering. The span is the explicit "how close counts as coplanar" semantic parameter.
- The bias is applied identically in the depth pass, the color pass (`@builtin(frag_depth)`), and the OIT depth write, so coplanar surfaces become strictly ordered at the depth-test level — ties disappear entirely, including across the VItem/MeshItem pipelines (shared depth buffer), and the OIT resolve's depth sort now also breaks coplanar ties by insertion order.
- Order transport: VItems stash the order in the previously unused `PlaneData.origin.w`; MeshItems get a per-mesh `orders` storage buffer read in the fragment stage.
- The VItem/MeshItem depth and color pass pairs are now `.chain()`ed for deterministic execution.

## Verification

The `z_fighting` example renders coincident pairs (identical squares, square+circle, translucent, z-gap sweeps from 0 to 1e-1) from straight-on, angled ortho, and orbiting perspective cameras, with a pixel-classification harness:

| scene (angled camera) | before | after |
|---|---|---|
| `z_precision_angled` streaks per pair | 3.6%–45% of circle pixels | ≤0.11% (visually clean) |
| `flicker` blue share over time | 0.16–0.97 | 0.978 ± 0.001 |
| straight-on scenes | already correct | unchanged |
| translucent pairs | uniform | unchanged |

All `ranim-render` tests pass (9/9).

---

- **fix**: 共面表面现在按场景插入顺序解析，而不是依赖光栅化舍入（`ranim-render` 中的按序深度偏置）。
- **test**: 新增 `z_fighting` example 复现该问题，并作为像素级回归测试集。

### Breaking Changes

- **`VItemsBuffer::update` / `MeshItemsBuffer::update`（`ranim-render`）**：物品迭代器现在产出 `(scene_order: f32, item)` 对，渲染器据此按全局场景顺序偏置深度。迁移方式：传入前将每个物品与其 `SceneOrder` 值配对。

---

## 问题

占据相同位置的物品应按场景插入顺序（加入场景的顺序）绘制，且结果必须稳定。CPU 侧的顺序链路本就正确（`SceneOrder` → 稳定排序 → instance index），但 GPU 侧破坏了这一保证：

- 深度 pass（`Less`、写深度）加颜色 pass（`LessEqual`、不写深度）使得共面几何的逐像素胜负由插值舍入决定；并列（tie）时回退到光栅化顺序，而单次 draw call 内的 instance 顺序并无保证。
- 半透明物品走 OIT 路径：层序是 `atomicAdd` 到达序，resolve 只按深度排序——共面并列保持到达序而非插入序。
- VItem 与 MeshItem 的 depth/color pass 彼此之间未定序。

在新增的 `z_fighting` example 上实测（斜视角正交相机，红色方块先于共面蓝色圆插入）：圆内 0.9%–45% 的像素被先插入的方块占据，比例随屏幕位置、场景内容与相机角度变化；相机运动时胜负随时间翻转（逐帧蓝占比 0.16–0.97）。单独渲染该 pair 时问题消失，加入无关物品后复现，且不随 near/far 范围缩放——即这是深度并列上的调度/舍入竞态，不是 CPU 排序 bug。

## 修复：场景顺序深度偏置

每个物品本就携带全局 `SceneOrder`（跨所有物品类型的帧内索引）。现在用该顺序把片段深度向相机方向偏置：

```wgsl
fn ordered_depth(frag_z: f32, order: f32) -> f32 {
    return frag_z - cam_uniforms.bias_epsilon * order;
}
```

- `bias_epsilon = DEPTH_ORDER_SPAN / item_count` 每帧计算，总偏移封顶于 `DEPTH_ORDER_SPAN`（1e-4 归一化深度，默认 ±1000 相机下约 0.2 世界单位），不随场景规模增长。
- 真实深度差小于该跨度的物品按插入顺序解析；差距更大的保持真实深度排序。该跨度就是显式的"多近算共面"语义参数。
- 偏置在深度 pass、颜色 pass（`@builtin(frag_depth)`）、OIT 深度写入三处完全一致，共面表面在深度测试层面变为严格有序——tie 彻底消失，包括跨 VItem/MeshItem 管线（共享深度缓冲），OIT resolve 的深度排序也随之按插入顺序打破并列。
- 顺序传输：VItem 把 order 存入原本空置的 `PlaneData.origin.w`；MeshItem 新增 per-mesh `orders` storage buffer（fragment 阶段读取）。
- VItem/MeshItem 的 depth 与 color pass 对改为 `.chain()` 定序，保证执行确定性。

## 验证

`z_fighting` example 在正对、斜视角正交、环绕透视三种相机下渲染共面对（相同方块、方+圆、半透明、0 到 1e-1 的 z 间距扫描），配合像素分类脚本：

| 场景（斜视角） | 修复前 | 修复后 |
|---|---|---|
| `z_precision_angled` 各 pair 条纹 | 圆内 3.6%–45% 像素 | ≤0.11%（目视干净） |
| `flicker` 蓝占比随时间 | 0.16–0.97 | 0.978 ± 0.001 |
| 正对相机场景 | 本就正确 | 不变 |
| 半透明 pair | 单色均匀 | 不变 |

`ranim-render` 全部测试通过（9/9）。
