### PR TITLE
docs(agents): require the whole PR body in both languages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,13 +52,19 @@ repository. It applies to both human contributors and AI coding agents.
 ### Language
 
 - PR titles and commit messages are always written in **English**.
-- The PR description is bilingual: English first, then Chinese, separated by a
-  `---` divider. Both versions carry the same content, including the
-  `Closes:` line and the Breaking Changes section.
+- The PR description is fully bilingual: write the **entire** description in
+  English first, then repeat the **entire** description in Chinese, separated
+  by a single `---` divider. "Entire" means every section — the summary
+  bullets, the Breaking Changes section, and all detail sections alike.
+  Translating only the top summary is the most common mistake and does not
+  count as bilingual.
 
 ### PR Description Format
 
-When creating or editing a PR, follow this structure:
+When creating or editing a PR, follow this structure. It shows **one
+language half**; the finished description is this structure twice — English
+first, then Chinese after the single `---` divider (see **The bilingual
+split** below):
 
 ```
 Closes: #<issue-number>
@@ -74,8 +80,6 @@ Closes: #<issue-number>
 
 - **API/Field name**: Description of the breaking change and migration path
 
----
-
 ## Component/Feature 1
 
 Detailed description of the first major change.
@@ -86,6 +90,15 @@ Use code blocks, mermaid diagrams, or examples as needed.
 
 ...
 ```
+
+#### The bilingual split
+
+- The `---` divider appears exactly **once**, between the English half and
+  the Chinese half — never between the summary and the detail sections.
+- Below the divider, repeat the document above **in full and in the same
+  order**: summary bullets → Breaking Changes → every detail section,
+  heading for heading. Only the language changes; the content stays
+  identical.
 
 #### Top section
 


### PR DESCRIPTION
- **docs**: AGENTS.md's PR-authoring guide now states that the **entire** PR description is repeated in Chinese below the single `---` divider — summary bullets, Breaking Changes, and every detail section alike — instead of naming only the `Closes:` line and Breaking Changes. The format template is relabeled as showing **one language half**, its misleading mid-template `---` divider is removed, and a new "The bilingual split" section pins the divider's placement and the repeat-in-full rule.

---

- **docs**：AGENTS.md 的 PR 撰写指南现在明确——**整份** PR 描述都要在单独的 `---` 分隔线之后以中文重复：摘要、Breaking Changes 与所有细节章节一视同仁，而不是只点名 `Closes:` 行和 Breaking Changes。格式模板标注为展示**单个语言半侧**，移除了模板中部误导性的 `---` 分隔线，并新增 "The bilingual split" 小节固定分隔线位置与整份重复规则。
