### PR TITLE
fix(ranim-render): clamp depth-order bias epsilon with a ulp floor

### DIFF
--- a/packages/ranim-render/src/primitives/viewport.rs
+++ b/packages/ranim-render/src/primitives/viewport.rs
@@ -12,6 +12,49 @@ use crate::utils::{WgpuBuffer, WgpuContext};
 /// grow with scene size.
 pub const DEPTH_ORDER_SPAN: f32 = 1e-4;
 
+/// Lower bound for the per-order bias epsilon, in ulps of the f32 depth
+/// buffer at mid-depth.
+///
+/// `DEPTH_ORDER_SPAN / item_count` degenerates below one depth-ulp once a
+/// frame holds enough items (a text-heavy scene easily reaches thousands of
+/// per-glyph items): adjacent orders then round to the same stored depth and
+/// the bias no longer breaks ties. The floor keeps adjacent orders
+/// distinguishable at any scene size; the trade-off is that once the floor is
+/// active the effective "counts as coplanar" threshold grows linearly with
+/// item count.
+pub const MIN_ORDER_BIAS_ULPS: f32 = 16.0;
+
+/// f32 spacing at normalized depth 0.5; depths in `[0.25, 1]` share it.
+const DEPTH_ULP: f32 = f32::EPSILON / 2.0;
+
+/// Per-order depth bias epsilon for a frame holding `item_count` items.
+///
+/// Evenly splits [`DEPTH_ORDER_SPAN`] across the items, clamped from below at
+/// [`MIN_ORDER_BIAS_ULPS`] depth-ulps so the bias keeps breaking ties in
+/// dense scenes.
+pub fn depth_bias_epsilon(item_count: u32) -> f32 {
+    (DEPTH_ORDER_SPAN / item_count.max(1) as f32).max(MIN_ORDER_BIAS_ULPS * DEPTH_ULP)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epsilon_splits_span_for_small_scenes() {
+        let eps = depth_bias_epsilon(10);
+        assert!((eps - DEPTH_ORDER_SPAN / 10.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn epsilon_never_drops_below_the_ulp_floor() {
+        let eps = depth_bias_epsilon(1839);
+        assert_eq!(eps, MIN_ORDER_BIAS_ULPS * DEPTH_ULP);
+        // adjacent orders must stay at least one depth-ulp apart
+        assert!((eps * 1839.0) > MIN_ORDER_BIAS_ULPS * DEPTH_ULP);
+    }
+}
+
 /// Uniforms for the camera
 #[repr(C, align(16))]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
@@ -19,7 +62,7 @@ pub struct ViewportUniform {
     proj_mat: Mat4,
     view_mat: Mat4,
     half_frame_size: Vec2,
-    /// Per-order depth bias epsilon, see [`DEPTH_ORDER_SPAN`].
+    /// Per-order depth bias epsilon, see [`depth_bias_epsilon`].
     bias_epsilon: f32,
     _padding: u32,
 }

--- a/packages/ranim-render/src/schedule.rs
+++ b/packages/ranim-render/src/schedule.rs
@@ -228,10 +228,11 @@ fn view_driver(world: &mut World) {
     let camera = take_single_camera(cameras);
     let dimensions = *world.resource::<RenderDimensions>();
     // The per-order depth bias epsilon: the fixed span is split evenly across
-    // all items of the frame so the total offset stays bounded.
+    // all items of the frame, with a ulp floor so it keeps breaking ties in
+    // dense scenes (see `depth_bias_epsilon`).
     let item_count = world.resource::<VItemsBuffer>().item_count()
         + world.resource::<MeshItemsBuffer>().item_count();
-    let bias_epsilon = crate::primitives::viewport::DEPTH_ORDER_SPAN / item_count.max(1) as f32;
+    let bias_epsilon = crate::primitives::viewport::depth_bias_epsilon(item_count);
     let uniform = ViewportUniform::from_camera_frame(
         &camera,
         dimensions.width,


### PR DESCRIPTION
- **fix**: Clamp the scene-order depth-bias epsilon with a ulp floor so it keeps breaking coplanar ties in dense scenes (`ranim-render`).

Refs #205.

### Breaking Changes

None. For frames with fewer than ~170 items the epsilon is unchanged; denser frames get a larger (but still sub-pixel) bias.

---

## Background

#201 introduced a scene-order depth bias to resolve coplanar surfaces by insertion order: every fragment's depth is pulled toward the camera by `epsilon * scene_order`, with `epsilon = DEPTH_ORDER_SPAN / item_count` so the total offset stays capped.

## Problem

`DEPTH_ORDER_SPAN / item_count` degenerates below one ulp of the f32 depth buffer once a frame holds enough items. A text-heavy scene (typst glyphs emitted as per-glyph VItems) easily reaches thousands of items per frame — at 1839 items the epsilon is ≈0.9 depth-ulps, so adjacent scene orders round to the same stored depth and the bias stops breaking ties.

## Fix

Clamp the epsilon with a floor expressed in depth-ulps:

```rust
pub const MIN_ORDER_BIAS_ULPS: f32 = 16.0;

pub fn depth_bias_epsilon(item_count: u32) -> f32 {
    (DEPTH_ORDER_SPAN / item_count.max(1) as f32).max(MIN_ORDER_BIAS_ULPS * DEPTH_ULP)
}
```

- Frames with fewer than ~170 items are unaffected (`SPAN / N` is still above the floor).
- Denser frames keep adjacent orders ≥16 depth-ulps apart; the trade-off is that the effective "counts as coplanar" threshold grows linearly with item count once the floor is active (at 1839 items it is ≈3.5 world units with the default ±1000 camera — irrelevant for flat 2D content).
- Added unit tests covering both regimes.

## Note on #205 reproduction

A probe against the `bpe_tokenizer` scene (1839 items) showed the rendered output is **byte-identical across epsilon scales from 0.9 ulp to 900 ulps**, including the reported artifacts. The bpe artifacts are therefore deterministic translucent stacking (repeated text copies composited through OIT), not depth races — they need a separate fix (content/eval-level), tracked in #205. The clamp remains worthwhile hardening for opaque coplanar ties in dense scenes.

---

- **fix**: 为场景顺序深度偏置的 epsilon 增加 ulp 下限，使其在密集场景下仍能打破共面并列（`ranim-render`）。

关联 #205。

### Breaking Changes

无。物品数少于约 170 的帧 epsilon 不变；更密集的帧会得到更大（但仍远小于一个像素）的偏置。

---

## 背景

#201 引入了场景顺序深度偏置，使共面表面按插入顺序解析：每个片段的深度向相机方向偏移 `epsilon * scene_order`，其中 `epsilon = DEPTH_ORDER_SPAN / item_count`，总偏移保持有界。

## 问题

一旦一帧中的物品足够多，`DEPTH_ORDER_SPAN / item_count` 就会退化到低于 f32 深度缓冲的一个 ulp。文本密集的场景（typst 字形按逐字形 VItem 输出）很容易达到每帧数千个物品——1839 个物品时 epsilon ≈ 0.9 个深度 ulp，相邻场景顺序舍入到相同的存储深度，偏置不再能打破并列。

## 修复

以深度 ulp 为单位给 epsilon 加下限：

```rust
pub const MIN_ORDER_BIAS_ULPS: f32 = 16.0;

pub fn depth_bias_epsilon(item_count: u32) -> f32 {
    (DEPTH_ORDER_SPAN / item_count.max(1) as f32).max(MIN_ORDER_BIAS_ULPS * DEPTH_ULP)
}
```

- 物品数少于约 170 的帧不受影响（`SPAN / N` 仍高于下限）。
- 更密集的帧中相邻 order 至少保持 16 个深度 ulp 的间隔；代价是下限生效后"多近算共面"的阈值随物品数线性增长（1839 个物品时在默认 ±1000 相机下约 3.5 世界单位——对平面 2D 内容无关紧要）。
- 新增单元测试覆盖两种 regime。

## 关于 #205 复现的说明

针对 `bpe_tokenizer` 场景（1839 个物品）的探针实验显示：epsilon 从 0.9 ulp 缩放到 900 ulps，渲染输出**逐字节不变**（包括报告的伪影）。因此 bpe 的伪影是确定性的半透明叠印（重复文本副本经 OIT 合成），而非深度竞态——需要单独的内容/求值层修复（见 #205）。本 clamp 仍是对密集场景下不透明共面并列的有效加固。
