### PR TITLE
fix(ranim-core): keep multi-contour glyph subpaths flagged closed

### DIFF
--- a/packages/ranim-core/src/components/vpoint.rs
+++ b/packages/ranim-core/src/components/vpoint.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 
+use approx::relative_eq;
+
 use derive_more::{Deref, DerefMut};
 use glam::DVec3;
 use itertools::Itertools;
@@ -287,20 +289,27 @@ impl VPointVec {
             .and_then(|seg| seg.try_into().ok())
     }
     /// Get closed path flags
+    ///
+    /// A subpath is closed when its last point equals its first. Every point
+    /// of a closed subpath inherits the flag; the shader skips the fill of
+    /// segments whose flag is false.
     pub fn get_closepath_flags(&self) -> Vec<bool> {
-        let len = self.len();
-        let mut flags = vec![false; len];
+        let mut flags = vec![false; self.len()];
 
-        // println!("{:?}", self.0);
-        let mut i = 0;
-        while let Some((end_idx, is_closed)) = self.get(i..).and_then(get_subpath_closed_flag) {
-            // println!("{i} {end_idx} {len}");
-            let end_idx = i + end_idx + 2;
-            flags[i..=end_idx.clamp(i, len - 1)].fill(is_closed);
-            i = end_idx;
+        let mut start = 0;
+        let mut last_closed = false;
+        for subpath in self.get_subpaths() {
+            let count = subpath.len();
+            let end = (start + count).min(self.len());
+            last_closed = count >= 2 && relative_eq!(subpath[0], subpath[count - 1]);
+            flags[start..end].fill(last_closed);
+            start = end;
         }
-        // println!("{:?}", flags);
-
+        // Points left over after the parsed subpaths (e.g. a trailing closing
+        // anchor) belong to the last subpath.
+        if start < self.len() {
+            flags[start..].fill(last_closed);
+        }
         flags
     }
 
@@ -623,5 +632,83 @@ mod test {
         let [min, max] = points.aabb();
         assert_dvec3_eq(min, DVec3::ZERO);
         assert_dvec3_eq(max, DVec3::ZERO);
+    }
+    // Regression: a TextItem "i" (stem + tittle contours) must keep both
+    // subpaths flagged closed, otherwise the tittle renders unfilled.
+    #[test]
+    fn repro_textitem_i_flags() {
+        let points = vec![
+            dvec3(-1.1095102, 0.2, 0.0),
+            dvec3(-1.1095102, 0.24466859, 0.0),
+            dvec3(-1.1095102, 0.2893372, 0.0),
+            dvec3(-0.965936, 0.2893372, 0.0),
+            dvec3(-0.93119603, 0.3029707, 0.0),
+            dvec3(-0.8847263, 0.3212075, 0.0),
+            dvec3(-0.8847263, 0.39596543, 0.0),
+            dvec3(-0.8847263, 0.8008646, 0.0),
+            dvec3(-0.8847263, 1.2057637, 0.0),
+            dvec3(-0.8847263, 1.3013107, 0.0),
+            dvec3(-0.92327094, 1.3273722, 0.0),
+            dvec3(-0.96078646, 1.3527378, 0.0),
+            dvec3(-1.0979828, 1.3527378, 0.0),
+            dvec3(-1.0979828, 1.3974065, 0.0),
+            dvec3(-1.0979828, 1.442075, 0.0),
+            dvec3(-0.89625365, 1.4579251, 0.0),
+            dvec3(-0.6945245, 1.4737753, 0.0),
+            dvec3(-0.6945245, 0.93487036, 0.0),
+            dvec3(-0.6945245, 0.39596543, 0.0),
+            dvec3(-0.6945245, 0.32224214, 0.0),
+            dvec3(-0.65309805, 0.30372962, 0.0),
+            dvec3(-0.6208913, 0.2893372, 0.0),
+            dvec3(-0.49279544, 0.2893372, 0.0),
+            dvec3(-0.49279544, 0.24466859, 0.0),
+            dvec3(-0.49279544, 0.2, 0.0),
+            dvec3(-0.52158666, 0.2, 0.0),
+            dvec3(-0.60612535, 0.20347658, 0.0),
+            dvec3(-0.7318171, 0.20864554, 0.0),
+            dvec3(-0.79538906, 0.20864554, 0.0),
+            dvec3(-0.85056424, 0.20864554, 0.0),
+            dvec3(-0.9803795, 0.20371476, 0.0),
+            dvec3(-1.0781803, 0.2, 0.0),
+            dvec3(-1.1095102, 0.2, 0.0),
+            dvec3(-1.1095102, 0.2, 0.0),
+            dvec3(-1.1095102, 0.2, 0.0),
+            dvec3(-1.1095102, 0.2, 0.0),
+            dvec3(-0.8328531, 1.8224784, 0.0),
+            dvec3(-0.766148, 1.8224784, 0.0),
+            dvec3(-0.72442365, 1.8653458, 0.0),
+            dvec3(-0.68299717, 1.9079074, 0.0),
+            dvec3(-0.68299717, 1.9752162, 0.0),
+            dvec3(-0.68299717, 2.0446506, 0.0),
+            dvec3(-0.73126805, 2.0868876, 0.0),
+            dvec3(-0.7749074, 2.125072, 0.0),
+            dvec3(-0.8357349, 2.125072, 0.0),
+            dvec3(-0.89681745, 2.125072, 0.0),
+            dvec3(-0.9387609, 2.0879683, 0.0),
+            dvec3(-0.9855908, 2.0465417, 0.0),
+            dvec3(-0.9855908, 1.9752162, 0.0),
+            dvec3(-0.9855908, 1.9138817, 0.0),
+            dvec3(-0.95028824, 1.87183, 0.0),
+            dvec3(-0.9088573, 1.8224784, 0.0),
+            dvec3(-0.8328531, 1.8224784, 0.0),
+        ];
+        let vp = VPointVec(points.clone());
+        println!("n = {}", points.len());
+        println!("closepath_flags = {:?}", vp.get_closepath_flags());
+        let subpaths = vp.get_subpaths();
+        println!("subpaths = {}", subpaths.len());
+        for (i, sp) in subpaths.iter().enumerate() {
+            println!(
+                "  sp{i}: {} pts first=({:?}) last=({:?})",
+                sp.len(),
+                sp.first().unwrap(),
+                sp.last().unwrap()
+            );
+        }
+        let flags = vp.get_closepath_flags();
+        assert!(
+            flags.iter().all(|f| *f),
+            "some segments flagged open: {flags:?}"
+        );
     }
 }


### PR DESCRIPTION
- **fix**: Multi-contour glyphs (e.g. the tittle of "i") now render their fills — `VPointVec::get_closepath_flags` mis-flagged second-and-later subpath segments as open, and the render shader skips fills of segments flagged open (`ranim-core`).

### Breaking Changes

None. `get_closepath_flags` output changes only for the previously-broken cases; well-formed single- and multi-subpath items that rendered correctly keep identical flags.

---

## Symptom

In text rendered from glyph outlines (typst / `TextItem`), the tittle of lowercase "i" did not render: only a thin stroke outline of the dot was visible, and in animated scenes the detached dot could appear to "float" beside the glyph.

## Root cause

The render shader skips the fill of any segment whose closed flag is false (`item_is_closed`). The per-point closed flags come from `VPointVec::get_closepath_flags`, which scanned suffix slices with `get_subpath_closed_flag` and advanced the slice by `end_idx + 2`. For multi-contour glyph data (a lowercase "i" = stem contour + tittle contour) the slice boundaries misaligned: the second contour's segments — including points at the stem's baseline — were flagged open even though the contour is geometrically closed (first point == last point).

Reproduced as a unit test on `ranim-core` with the real `TextItem::new("ili")` point data (53 points): the tittle's 19 segments evaluated to `closed = false` while both subpaths satisfy `first == last`.

## Fix

Rewrite `get_closepath_flags` on top of `get_subpaths()`, which parses the vpoint encoding correctly:

- each subpath is closed when its first point equals its last;
- every point of the subpath (including the repeated closing anchor used as the subpath-break marker) inherits that flag;
- any trailing points not consumed by the parser belong to the last subpath.

Single-contour items and items whose subpaths are intentionally collapsed (morph alignment shrinking extra contours to their centroid) keep their previous flags.

## Verification

- New regression test `repro_textitem_i_flags` using the real TextItem "i" point data: fails before (19 segments flagged open), passes after.
- Static render of `TypstText` and `TextItem` "ili widest": tittles filled in all variants, including the lagged-fade-in one.
- The `bpe_tokenizer` one-shot example re-rendered: "lies" / "widest" chips show filled tittles; all `ranim-core` tests pass.

---

- **fix**: 多轮廓字形（例如 "i" 的点）现在能正常填充——`VPointVec::get_closepath_flags` 把第二个及之后的子路径段错误标记为开放，而渲染 shader 会跳过标记为开放的段的填充（`ranim-core`）。

### Breaking Changes

无。`get_closepath_flags` 的输出仅在之前损坏的情形下发生变化；原本渲染正确的单子路径和多子路径物品的标志保持不变。

---

## 症状

由字形轮廓渲染的文字（typst / `TextItem`）中，小写 "i" 的点渲染不出来：只能看到点的一个细描边轮廓，在动画场景里脱离的点还会看起来"漂浮"在字形旁边。

## 根因

渲染 shader 会跳过 closed 标志为 false 的段的填充（`item_is_closed`）。逐点 closed 标志来自 `VPointVec::get_closepath_flags`，它用 `get_subpath_closed_flag` 扫描后缀切片并以 `end_idx + 2` 推进切片边界。对多轮廓字形数据（小写 "i" = 杆轮廓 + 点轮廓），切片边界错位：第二个轮廓的段——包括杆基线上的点——被标记为开放，尽管该轮廓几何上是闭合的（首点 == 尾点）。

用 `ranim-core` 的单元测试复现：使用真实的 `TextItem::new("ili")` 点数据（53 个点），点的 19 个段求值为 `closed = false`，而两个子路径都满足 `first == last`。

## 修复

基于 `get_subpaths()` 重写 `get_closepath_flags`（该解析是正确的）：

- 每个子路径在其首点等于尾点时为闭合；
- 子路径的每个点（包括用作子路径分隔标记的重复闭合锚点）继承该标志；
- 解析器未消费的尾部点属于最后一个子路径。

单轮廓物品、以及子路径被有意收缩（morph 对齐把多余轮廓收缩到质心）的物品，保持原有标志。

## 验证

- 新增回归测试 `repro_textitem_i_flags`，使用真实的 TextItem "i" 点数据：修复前失败（19 个段标记为开放），修复后通过。
- `TypstText` 与 `TextItem` 的 "ili widest" 静态渲染：所有变体（包括 lagged fade-in）的点均实心填充。
- 重新渲染 `bpe_tokenizer` one-shot example："lies" / "widest" 芯片的点正常填充；`ranim-core` 全部测试通过。
